### PR TITLE
feat: add smooth scroll to thread viewport

### DIFF
--- a/packages/react/src/primitives/thread/ThreadViewport.tsx
+++ b/packages/react/src/primitives/thread/ThreadViewport.tsx
@@ -18,16 +18,27 @@ export const ThreadViewport = forwardRef<
   ThreadViewportElement,
   ThreadViewportProps
 >(({ onScroll, children, ...rest }, forwardedRef) => {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
   const divRef = useRef<HTMLDivElement>(null);
   const ref = useComposedRefs(forwardedRef, divRef);
 
   const [isAtBottom, setIsAtBottom] = useState(true);
 
-  useOnResizeContent(divRef, () => {
-    const div = divRef.current;
-    if (!div || !isAtBottom) return;
+  const firstRenderRef = useRef(true);
+  const scrollToBottom = () => {
+    const div = messagesEndRef.current;
+    if (!div) return;
 
-    div.scrollTop = div.scrollHeight;
+    const behavior = firstRenderRef.current ? "instant" : "auto";
+    firstRenderRef.current = false;
+
+    div.scrollIntoView({ behavior });
+  };
+
+  useOnResizeContent(divRef, () => {
+    if (!isAtBottom) return;
+    scrollToBottom();
   });
 
   const handleScroll = () => {
@@ -44,6 +55,7 @@ export const ThreadViewport = forwardRef<
       ref={ref}
     >
       {children}
+      <div ref={messagesEndRef} />
     </Primitive.div>
   );
 });

--- a/packages/shadcn/registry/assistant-ui/thread.tsx
+++ b/packages/shadcn/registry/assistant-ui/thread.tsx
@@ -28,7 +28,7 @@ import {
 export const Thread: FC = () => {
   return (
     <ThreadPrimitive.Root className="flex h-full flex-col items-center px-4 pb-3">
-      <ThreadPrimitive.Viewport className="flex w-full flex-grow flex-col items-center overflow-y-scroll pt-16">
+      <ThreadPrimitive.Viewport className="flex w-full flex-grow flex-col items-center overflow-y-scroll scroll-smooth pt-16">
         <ThreadPrimitive.Empty>
           <ThreadEmpty />
         </ThreadPrimitive.Empty>


### PR DESCRIPTION
Add smooth scrolling behavior when reaching the bottom of the thread viewport
to improve user experience. scrollTop is now smoothly adjusted instead of jumping.