### PR TITLE
fix: Keep isAtBottom true while smoothly scrolling

### DIFF
--- a/packages/react/src/primitives/thread/ThreadViewport.tsx
+++ b/packages/react/src/primitives/thread/ThreadViewport.tsx
@@ -30,12 +30,16 @@ export const ThreadViewport = forwardRef<
   const { useThread } = useAssistantContext();
 
   const firstRenderRef = useRef(true);
+  const scrollingToBottomRef = useRef(false);
   const scrollToBottom = () => {
     const div = messagesEndRef.current;
     if (!div || !autoScroll) return;
 
     const behavior = firstRenderRef.current ? "instant" : "auto";
     firstRenderRef.current = false;
+
+    scrollingToBottomRef.current = true;
+    useThread.setState({ isAtBottom: true });
 
     div.scrollIntoView({ behavior });
   };
@@ -57,7 +61,11 @@ export const ThreadViewport = forwardRef<
     const newIsAtBottom =
       div.scrollHeight - div.scrollTop <= div.clientHeight + 50;
 
-    if (newIsAtBottom !== isAtBottom) {
+    if (isAtBottom && scrollingToBottomRef.current) {
+      if (newIsAtBottom) {
+        scrollingToBottomRef.current = false;
+      }
+    } else if (newIsAtBottom !== isAtBottom) {
       useThread.setState({ isAtBottom: newIsAtBottom });
     }
   };

--- a/packages/react/src/primitives/thread/ThreadViewport.tsx
+++ b/packages/react/src/primitives/thread/ThreadViewport.tsx
@@ -30,7 +30,9 @@ export const ThreadViewport = forwardRef<
   const { useThread } = useAssistantContext();
 
   const firstRenderRef = useRef(true);
-  const scrollingToBottomRef = useRef(false);
+  const scrollingToBottomRef = useRef<false | ReturnType<typeof setTimeout>>(
+    false,
+  );
   const scrollToBottom = () => {
     const div = messagesEndRef.current;
     if (!div || !autoScroll) return;
@@ -38,7 +40,10 @@ export const ThreadViewport = forwardRef<
     const behavior = firstRenderRef.current ? "instant" : "auto";
     firstRenderRef.current = false;
 
-    scrollingToBottomRef.current = true;
+    scrollingToBottomRef.current = setTimeout(() => {
+      scrollingToBottomRef.current = false;
+      handleScroll();
+    }, 500);
     useThread.setState({ isAtBottom: true });
 
     div.scrollIntoView({ behavior });


### PR DESCRIPTION
New onScroll events cause isAtBottom to turn false while smooth scrolling is enabled. Ignore these events during the transition