### PR TITLE
feat: Focus on main composer whenever scroll-to-bottom is triggered

### DIFF
--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -3,12 +3,19 @@
 import { composeEventHandlers } from "@radix-ui/primitive";
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { Slot } from "@radix-ui/react-slot";
-import { type KeyboardEvent, forwardRef, useEffect, useRef } from "react";
+import {
+  type KeyboardEvent,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
 import TextareaAutosize, {
   type TextareaAutosizeProps,
 } from "react-textarea-autosize";
 import { useAssistantContext } from "../../utils/context/AssistantContext";
 import { useComposerContext } from "../../utils/context/useComposerContext";
+import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
 
 type ComposerInputProps = TextareaAutosizeProps & {
   asChild?: boolean;
@@ -23,7 +30,7 @@ export const ComposerInput = forwardRef<
     forwardedRef,
   ) => {
     const { useThread } = useAssistantContext();
-    const { useComposer } = useComposerContext();
+    const { useComposer, type } = useComposerContext();
 
     const value = useComposer((c) => {
       if (!c.isEditing) return "";
@@ -54,7 +61,7 @@ export const ComposerInput = forwardRef<
     const ref = useComposedRefs(forwardedRef, textareaRef);
 
     const autoFocusEnabled = autoFocus !== false && !disabled;
-    useEffect(() => {
+    const focus = useCallback(() => {
       const textarea = textareaRef.current;
       if (!textarea || !autoFocusEnabled) return;
 
@@ -64,6 +71,14 @@ export const ComposerInput = forwardRef<
         textareaRef.current.value.length,
       );
     }, [autoFocusEnabled]);
+
+    useEffect(() => focus(), [focus]);
+
+    useOnScrollToBottom(() => {
+      if (type === "assistant") {
+        focus();
+      }
+    });
 
     return (
       <Component

--- a/packages/react/src/utils/context/useComposerContext.ts
+++ b/packages/react/src/utils/context/useComposerContext.ts
@@ -5,5 +5,8 @@ import { MessageContext } from "./useMessageContext";
 export const useComposerContext = () => {
   const { useComposer: useAssisstantComposer } = useAssistantContext();
   const { useComposer: useMessageComposer } = useContext(MessageContext) ?? {};
-  return { useComposer: useMessageComposer ?? useAssisstantComposer };
+  return {
+    useComposer: useMessageComposer ?? useAssisstantComposer,
+    type: useMessageComposer ? ("message" as const) : ("assistant" as const),
+  };
 };


### PR DESCRIPTION
This is a little hacky, but it handles edits, reloads as well as scroll to bottom button presses. In all cases, it is desired that the main composer is focused again