### PR TITLE
fix: Update ScrollToBottom button styles

### DIFF
--- a/packages/shadcn/registry/assistant-ui/thread.tsx
+++ b/packages/shadcn/registry/assistant-ui/thread.tsx
@@ -63,15 +63,17 @@ const ThreadEmpty: FC = () => {
 
 const ThreadScrollToBottom: FC = () => {
   return (
-    <ThreadPrimitive.ScrollToBottom asChild>
-      <IconButton
-        tooltip="Scroll to bottom"
-        variant="outline"
-        className="sticky bottom-3 rounded-full disabled:invisible"
-      >
-        <ArrowDownIcon className="size-4" />
-      </IconButton>
-    </ThreadPrimitive.ScrollToBottom>
+    <div className="sticky bottom-0">
+      <ThreadPrimitive.ScrollToBottom asChild>
+        <IconButton
+          tooltip="Scroll to bottom"
+          variant="outline"
+          className="-top-10 absolute rounded-full disabled:invisible"
+        >
+          <ArrowDownIcon className="size-4" />
+        </IconButton>
+      </ThreadPrimitive.ScrollToBottom>
+    </div>
   );
 };
 


### PR DESCRIPTION
The button should not take any space in the Viewport