### PR TITLE
refactor: Thread Context - Add ThreadComposerState/Store

### DIFF
--- a/packages/react/src/adapters/vercel/useDummyAIAssistantContext.tsx
+++ b/packages/react/src/adapters/vercel/useDummyAIAssistantContext.tsx
@@ -6,7 +6,7 @@ import {
   ROOT_PARENT_ID,
   type ThreadState,
 } from "../../utils/context/stores/AssistantTypes";
-import { makeThreadComposer } from "../../utils/context/stores/ComposerStore";
+import { makeThreadComposerStore } from "../../utils/context/stores/ComposerStore";
 
 export const useDummyAIAssistantContext = () => {
   const [context] = useState<AssistantStore>(() => {

--- a/packages/react/src/adapters/vercel/useDummyAIAssistantContext.tsx
+++ b/packages/react/src/adapters/vercel/useDummyAIAssistantContext.tsx
@@ -6,7 +6,7 @@ import {
   ROOT_PARENT_ID,
   type ThreadState,
 } from "../../utils/context/stores/AssistantTypes";
-import { makeThreadComposer } from "../../utils/context/stores/ComposerTypes";
+import { makeThreadComposer } from "../../utils/context/stores/ComposerStore";
 
 export const useDummyAIAssistantContext = () => {
   const [context] = useState<AssistantStore>(() => {

--- a/packages/react/src/adapters/vercel/useDummyAIAssistantContext.tsx
+++ b/packages/react/src/adapters/vercel/useDummyAIAssistantContext.tsx
@@ -41,7 +41,7 @@ export const useDummyAIAssistantContext = () => {
       },
     }));
 
-    const useComposer = makeThreadComposer({
+    const useComposer = makeThreadComposerStore({
       onSend: async (text) => {
         await useThread.getState().append({
           parentId: useThread.getState().messages.at(-1)?.id ?? ROOT_PARENT_ID,

--- a/packages/react/src/primitives/message/MessageProvider.tsx
+++ b/packages/react/src/primitives/message/MessageProvider.tsx
@@ -11,7 +11,7 @@ import type {
   ThreadMessage,
   ThreadState,
 } from "../../utils/context/stores/AssistantTypes";
-import { makeMessageComposer } from "../../utils/context/stores/ComposerStore";
+import { makeMessageComposerStore } from "../../utils/context/stores/ComposerStore";
 import type {
   MessageState,
   MessageStore,
@@ -42,7 +42,7 @@ const useMessageContext = () => {
       setIsHovering: () => {},
     }));
 
-    const useComposer = makeMessageComposer({
+    const useComposer = makeMessageComposerStore({
       onEdit: () => {
         const message = useMessage.getState().message;
         if (message.role !== "user")

--- a/packages/react/src/primitives/message/MessageProvider.tsx
+++ b/packages/react/src/primitives/message/MessageProvider.tsx
@@ -11,7 +11,7 @@ import type {
   ThreadMessage,
   ThreadState,
 } from "../../utils/context/stores/AssistantTypes";
-import { makeMessageComposer } from "../../utils/context/stores/ComposerTypes";
+import { makeMessageComposer } from "../../utils/context/stores/ComposerStore";
 import type {
   MessageState,
   MessageStore,

--- a/packages/react/src/utils/context/stores/AssistantTypes.ts
+++ b/packages/react/src/utils/context/stores/AssistantTypes.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import type { StoreApi, UseBoundStore } from "zustand";
-import type { ComposerStore } from "./ComposerTypes";
+import type { ThreadComposerStore } from "./ComposerStore";
 
 // TODO metadata field
 
@@ -75,7 +75,7 @@ export type ThreadState = {
   onScrollToBottom: (callback: () => void) => () => void;
 };
 
-export type AssistantStore = ComposerStore & {
+export type AssistantStore = ThreadComposerStore & {
   useThread: UseBoundStore<StoreApi<ThreadState>>;
 };
 

--- a/packages/react/src/utils/context/stores/AssistantTypes.ts
+++ b/packages/react/src/utils/context/stores/AssistantTypes.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import type { StoreApi, UseBoundStore } from "zustand";
-import type { ThreadComposerStore } from "./ComposerStore";
+import type { ThreadComposerState } from "./ComposerStore";
 
 // TODO metadata field
 
@@ -75,8 +75,9 @@ export type ThreadState = {
   onScrollToBottom: (callback: () => void) => () => void;
 };
 
-export type AssistantStore = ThreadComposerStore & {
+export type AssistantStore = {
   useThread: UseBoundStore<StoreApi<ThreadState>>;
+  useComposer: UseBoundStore<StoreApi<ThreadComposerState>>;
 };
 
 export const ROOT_PARENT_ID = "__ROOT_ID__";

--- a/packages/react/src/utils/context/stores/ComposerStore.ts
+++ b/packages/react/src/utils/context/stores/ComposerStore.ts
@@ -22,7 +22,7 @@ const makeBaseComposer: StateCreator<
   },
 });
 
-type MessageComposerState = BaseComposerState & {
+export type MessageComposerState = BaseComposerState & {
   isEditing: boolean;
   canCancel: true;
 
@@ -31,17 +31,13 @@ type MessageComposerState = BaseComposerState & {
   cancel: () => void;
 };
 
-export type MessageComposerStore = {
-  useComposer: UseBoundStore<StoreApi<MessageComposerState>>;
-};
-
-export const makeMessageComposer = ({
+export const makeMessageComposerStore = ({
   onEdit,
   onSend,
 }: {
   onEdit: () => string;
   onSend: (value: string) => Promise<void>;
-}) =>
+}): UseBoundStore<StoreApi<MessageComposerState>> =>
   create<MessageComposerState>()((set, get, store) => ({
     ...makeBaseComposer(set, get, store),
 
@@ -62,7 +58,7 @@ export const makeMessageComposer = ({
     },
   }));
 
-type ThreadComposerState = BaseComposerState & {
+export type ThreadComposerState = BaseComposerState & {
   isEditing: true;
   canCancel: boolean;
 
@@ -70,17 +66,13 @@ type ThreadComposerState = BaseComposerState & {
   cancel: () => void;
 };
 
-export type ThreadComposerStore = {
-  useComposer: UseBoundStore<StoreApi<ThreadComposerState>>;
-};
-
-export const makeThreadComposer = ({
+export const makeThreadComposerStore = ({
   onSend,
   onCancel,
 }: {
   onSend: (value: string) => Promise<void>;
   onCancel: () => void;
-}) =>
+}): StoreApi<ThreadComposerState> =>
   create<ThreadComposerState>()((set, get, store) => ({
     ...makeBaseComposer(set, get, store),
 

--- a/packages/react/src/utils/context/stores/ComposerStore.ts
+++ b/packages/react/src/utils/context/stores/ComposerStore.ts
@@ -72,7 +72,7 @@ export const makeThreadComposerStore = ({
 }: {
   onSend: (value: string) => Promise<void>;
   onCancel: () => void;
-}): StoreApi<ThreadComposerState> =>
+}): UseBoundStore<StoreApi<ThreadComposerState>> =>
   create<ThreadComposerState>()((set, get, store) => ({
     ...makeBaseComposer(set, get, store),
 

--- a/packages/react/src/utils/context/stores/ComposerStore.ts
+++ b/packages/react/src/utils/context/stores/ComposerStore.ts
@@ -1,26 +1,38 @@
-import { type StoreApi, type UseBoundStore, create } from "zustand";
+import {
+  type StateCreator,
+  type StoreApi,
+  type UseBoundStore,
+  create,
+} from "zustand";
 
-export type ComposerState = {
-  isEditing: boolean;
-  canCancel: boolean;
-
-  send: () => void;
-  cancel: () => void;
-
+type BaseComposerState = {
   value: string;
   setValue: (value: string) => void;
 };
 
-export type MessageComposerState = ComposerState & {
+const makeBaseComposer: StateCreator<
+  BaseComposerState,
+  [],
+  [],
+  BaseComposerState
+> = (set) => ({
+  value: "",
+  setValue: (value) => {
+    set({ value });
+  },
+});
+
+type MessageComposerState = BaseComposerState & {
+  isEditing: boolean;
+  canCancel: true;
+
   edit: () => void;
+  send: () => void;
+  cancel: () => void;
 };
 
 export type MessageComposerStore = {
   useComposer: UseBoundStore<StoreApi<MessageComposerState>>;
-};
-
-export type ComposerStore = {
-  useComposer: UseBoundStore<StoreApi<ComposerState>>;
 };
 
 export const makeMessageComposer = ({
@@ -30,15 +42,11 @@ export const makeMessageComposer = ({
   onEdit: () => string;
   onSend: (value: string) => Promise<void>;
 }) =>
-  create<MessageComposerState>()((set, get) => ({
+  create<MessageComposerState>()((set, get, store) => ({
+    ...makeBaseComposer(set, get, store),
+
     canCancel: true,
-
     isEditing: false,
-
-    value: "",
-    setValue: (value) => {
-      set({ value });
-    },
 
     edit: () => {
       const value = onEdit();
@@ -54,6 +62,18 @@ export const makeMessageComposer = ({
     },
   }));
 
+type ThreadComposerState = BaseComposerState & {
+  isEditing: true;
+  canCancel: boolean;
+
+  send: () => void;
+  cancel: () => void;
+};
+
+export type ThreadComposerStore = {
+  useComposer: UseBoundStore<StoreApi<ThreadComposerState>>;
+};
+
 export const makeThreadComposer = ({
   onSend,
   onCancel,
@@ -61,15 +81,11 @@ export const makeThreadComposer = ({
   onSend: (value: string) => Promise<void>;
   onCancel: () => void;
 }) =>
-  create<ComposerState>()((set, get) => ({
+  create<ThreadComposerState>()((set, get, store) => ({
+    ...makeBaseComposer(set, get, store),
+
     isEditing: true,
-
     canCancel: false,
-
-    value: "",
-    setValue: (value) => {
-      set({ value });
-    },
 
     send: () => {
       const value = get().value;

--- a/packages/react/src/utils/context/stores/MessageTypes.ts
+++ b/packages/react/src/utils/context/stores/MessageTypes.ts
@@ -1,6 +1,6 @@
 import type { StoreApi, UseBoundStore } from "zustand";
 import type { ThreadMessage } from "./AssistantTypes";
-import type { MessageComposerStore } from "./ComposerTypes";
+import type { MessageComposerStore } from "./ComposerStore";
 
 export type MessageState = {
   message: ThreadMessage;

--- a/packages/react/src/utils/context/stores/MessageTypes.ts
+++ b/packages/react/src/utils/context/stores/MessageTypes.ts
@@ -1,6 +1,6 @@
 import type { StoreApi, UseBoundStore } from "zustand";
 import type { ThreadMessage } from "./AssistantTypes";
-import type { MessageComposerStore } from "./ComposerStore";
+import type { MessageComposerState } from "./ComposerStore";
 
 export type MessageState = {
   message: ThreadMessage;
@@ -11,6 +11,7 @@ export type MessageState = {
   setIsHovering: (value: boolean) => void;
 };
 
-export type MessageStore = MessageComposerStore & {
+export type MessageStore = {
   useMessage: UseBoundStore<StoreApi<MessageState>>;
+  useComposer: UseBoundStore<StoreApi<MessageComposerState>>;
 };

--- a/packages/react/src/utils/context/useComposerContext.ts
+++ b/packages/react/src/utils/context/useComposerContext.ts
@@ -1,12 +1,19 @@
 import { useContext } from "react";
+import type { StoreApi, UseBoundStore } from "zustand";
 import { useAssistantContext } from "./AssistantContext";
+import type {
+  MessageComposerState,
+  ThreadComposerState,
+} from "./stores/ComposerStore";
 import { MessageContext } from "./useMessageContext";
 
 export const useComposerContext = () => {
   const { useComposer: useAssisstantComposer } = useAssistantContext();
   const { useComposer: useMessageComposer } = useContext(MessageContext) ?? {};
   return {
-    useComposer: useMessageComposer ?? useAssisstantComposer,
+    useComposer: (useMessageComposer ?? useAssisstantComposer) as UseBoundStore<
+      StoreApi<MessageComposerState | ThreadComposerState>
+    >,
     type: useMessageComposer ? ("message" as const) : ("assistant" as const),
   };
 };


### PR DESCRIPTION
Updated the import paths in several files to import from ComposerStore instead of ComposerTypes for consistency and clarity.