### PR TITLE
feat: add streaming with `useLocalRuntime`

### DIFF
--- a/.changeset/silly-otters-smash.md
+++ b/.changeset/silly-otters-smash.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(local-runtime): AsyncGenerator support

--- a/apps/docs/content/docs/docs/runtimes/custom-rest.mdx
+++ b/apps/docs/content/docs/docs/runtimes/custom-rest.mdx
@@ -120,3 +120,28 @@ export default function RootLayout({
 
   </Step>
 </Steps>
+
+## Streaming
+
+Declare the `run` function as an `AsyncGenerator` (`async *run`). This allows you to `yield` the results as they are generated.
+
+```tsx {2, 11-13}
+const MyModelAdapter: ChatModelAdapter = {
+  async *run({ messages, abortSignal, config }) {
+    const stream = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Say this is a test" }],
+      stream: true,
+    });
+
+    let text = "";
+    for await (const part of stream) {
+      text += part.choices[0]?.delta?.content || "";
+
+      yield {
+        content: [{ type: "text", text }],
+      };
+    }
+  },
+};
+```

--- a/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
+++ b/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
@@ -32,7 +32,7 @@ export type EdgeChatAdapterOptions = {
 export class EdgeChatAdapter implements ChatModelAdapter {
   constructor(private options: EdgeChatAdapterOptions) {}
 
-  async run({ messages, abortSignal, config, onUpdate }: ChatModelRunOptions) {
+  async *run({ messages, abortSignal, config }: ChatModelRunOptions) {
     const result = await fetch(this.options.api, {
       method: "POST",
       headers: {
@@ -61,7 +61,7 @@ export class EdgeChatAdapter implements ChatModelAdapter {
 
     let update: ChatModelRunResult | undefined;
     for await (update of asAsyncIterable(stream)) {
-      onUpdate(update);
+      yield update;
     }
     if (update === undefined)
       throw new Error("No data received from Edge Runtime");

--- a/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
+++ b/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
@@ -63,9 +63,8 @@ export class EdgeChatAdapter implements ChatModelAdapter {
     for await (update of asAsyncIterable(stream)) {
       yield update;
     }
+
     if (update === undefined)
       throw new Error("No data received from Edge Runtime");
-
-    return update;
   }
 }

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -29,5 +29,5 @@ export type ChatModelRunOptions = {
 };
 
 export type ChatModelAdapter = {
-  run: (options: ChatModelRunOptions) => Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult>;
+  run: (options: ChatModelRunOptions) => Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
 };

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -25,5 +25,5 @@ export type ChatModelRunOptions = {
 };
 
 export type ChatModelAdapter = {
-  run: (options: ChatModelRunOptions) => Promise<ChatModelRunResult>;
+  run: (options: ChatModelRunOptions) => Promise<ChatModelRunResult | AsyncGenerator<ChatModelRunResult>>;
 };

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -21,6 +21,10 @@ export type ChatModelRunOptions = {
   messages: ThreadMessage[];
   abortSignal: AbortSignal;
   config: ModelConfig;
+
+  /**
+   * @deprecated Declare the run function as an AsyncGenerator instead. This method will be removed in v0.6
+   */
   onUpdate: (result: ChatModelRunUpdate) => void;
 };
 

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -29,5 +29,5 @@ export type ChatModelRunOptions = {
 };
 
 export type ChatModelAdapter = {
-  run: (options: ChatModelRunOptions) => Promise<ChatModelRunResult | AsyncGenerator<ChatModelRunResult>>;
+  run: (options: ChatModelRunOptions) => Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult>;
 };

--- a/packages/react/src/runtimes/local/LocalThreadRuntime.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntime.tsx
@@ -169,6 +169,8 @@ export class LocalThreadRuntime implements ThreadRuntime {
             status: { type: "incomplete", reason: "error", error: e },
           });
           throw e;
+        } finally {
+          this.abortController = null;
         }
       } else {
         if (result.status?.type === "running")


### PR DESCRIPTION
add streaming support to local runtime via async iterator

Example

```ts
import { type ChatModelAdapter } from "@assistant-ui/react";

const CustomModelAdapter: ChatModelAdapter = {
  async run({ messages, signal }) {
    const res = await fetch("/api/chat", {
      method: "POST",
      body: JSON.stringify({ messages }),
      signal,
    });

    const reader = res.body.getReader();
    const decoder = new TextDecoder();
    let done = false;
    let content = '';

    return (async function* () {
      while (!done) {
        const { value, done: readerDone } = await reader.read();
        done = readerDone;
        if (value) {
          const chunk = decoder.decode(value, { stream: true });
          content += chunk;
          yield {
            content: [{ type: "text", text: content }],
            status: { type: "running" },
          };
        }
      }
    })();
  },
};

export default CustomModelAdapter;
```