### PR TITLE
fix: Typo in index.mdx

### DIFF
--- a/apps/docs/content/docs/runtimes/langgraph/index.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/index.mdx
@@ -14,7 +14,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 
 <Steps>
   <Step>
-  ### Create a new project based on te LangGraph assistant-ui template
+  ### Create a new project based on the LangGraph assistant-ui template
 
 ```sh
 npx assistant-ui@latest create -t langgraph my-app


### PR DESCRIPTION
Fixed a typo in the LangGraph Cloud Integration Docs

index.mdx
te -> the