### PR TITLE
Update README.md - fixed link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://assistant-ui.com">Product</a> ·
-  <a href="https://assistant-ui.com/docs">Documentation</a> ·
+  <a href="https://assistant-ui.com/docs/getting-started">Documentation</a> ·
   <a href="https://assistant-ui.com/examples">Examples</a> ·
   <a href="https://discord.gg/S9dwgCNEFs">Discord Community</a> ·
   <a href="https://cal.com/simon-farshid/assistant-ui">Contact Sales</a>


### PR DESCRIPTION
Docs pointed to https://assistant-ui.com/docs which was just a text dump. Fixed to point to https://assistant-ui.com/docs/getting-started.