### PR TITLE
[2024-10-09] [B2B] [General] Go to `/docs/getting-start` when opening docs in new window (cmd + click)

### DIFF
--- a/apps/docs/app/(home)/layout.tsx
+++ b/apps/docs/app/(home)/layout.tsx
@@ -39,7 +39,7 @@ function Footer(): React.ReactElement {
         <div className="mt-10 grid grid-cols-2 items-start gap-10 sm:mt-0">
           <div className="flex w-[160px] flex-col justify-center gap-4">
             <p className="text-sm">Product</p>
-            <FooterLink href="/docs">Documentation</FooterLink>
+            <FooterLink href="/docs/getting-started">Documentation</FooterLink>
             <FooterLink href="/examples">Examples</FooterLink>
             <FooterLink href="/blog">Blog</FooterLink>
           </div>

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -68,7 +68,7 @@ export default function HomePage() {
 
       <div className="mb-8 flex justify-center gap-2">
         <Button asChild>
-          <Link href="/docs">Get Started</Link>
+          <Link href="/docs/getting-started">Get Started</Link>
         </Button>
       </div>
       <div className="mx-auto flex w-full max-w-screen-xl flex-col">

--- a/apps/docs/app/(home)/shadcn-ui/page.tsx
+++ b/apps/docs/app/(home)/shadcn-ui/page.tsx
@@ -17,7 +17,7 @@ export default function HomePage() {
 
       <div className="mb-8 flex justify-center gap-2">
         <Button asChild>
-          <Link href="/docs">Get Started</Link>
+          <Link href="/docs/getting-started">Get Started</Link>
         </Button>
       </div>
       <div className="mx-auto flex w-full max-w-screen-xl flex-col">

--- a/apps/docs/app/docs/layout.config.tsx
+++ b/apps/docs/app/docs/layout.config.tsx
@@ -39,7 +39,7 @@ export const baseOptions: HomeLayoutProps = {
   links: [
     {
       text: "Documentation",
-      url: "/docs",
+      url: "/docs/getting-started",
       icon: <BookIcon />,
       active: "nested-url",
     },


### PR DESCRIPTION
## General

### Bug Fixes

- Go te getting-started on cmd + click (8bd4f1b23abfd350af24bc85ea07ebaa95223615)

---
Current behavior:

https://github.com/user-attachments/assets/210a33f9-ced7-459e-ad07-6d971ee24aaa