### PR TITLE
feat: Edge Runtime Server Accessible Ids

### DIFF
--- a/.changeset/fluffy-birds-burn.md
+++ b/.changeset/fluffy-birds-burn.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: Edge Runtime Server Accessible Ids (temp)

--- a/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
+++ b/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
@@ -31,12 +31,22 @@ export type EdgeChatAdapterOptions = {
   credentials?: RequestCredentials;
   headers?: Record<string, string> | Headers;
   body?: object;
+
+  /**
+   * When enabled, the adapter will not strip `id` from messages in the messages array.
+   */
+  unstable_sendMessageIds?: boolean;
 };
 
 export class EdgeChatAdapter implements ChatModelAdapter {
   constructor(private options: EdgeChatAdapterOptions) {}
 
-  async *run({ messages, abortSignal, config }: ChatModelRunOptions) {
+  async *run({
+    messages,
+    abortSignal,
+    config,
+    unstable_assistantMessageId,
+  }: ChatModelRunOptions) {
     const headers = new Headers(this.options.headers);
     headers.set("Content-Type", "application/json");
 
@@ -46,8 +56,11 @@ export class EdgeChatAdapter implements ChatModelAdapter {
       credentials: this.options.credentials ?? "same-origin",
       body: JSON.stringify({
         system: config.system,
-        messages: toCoreMessages(messages),
+        messages: toCoreMessages(messages, {
+          includeId: this.options.unstable_sendMessageIds,
+        }),
         tools: config.tools ? toLanguageModelTools(config.tools) : [],
+        unstable_assistantMessageId,
         ...config.callSettings,
         ...config.config,
 

--- a/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
+++ b/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
@@ -57,7 +57,7 @@ export class EdgeChatAdapter implements ChatModelAdapter {
       body: JSON.stringify({
         system: config.system,
         messages: toCoreMessages(messages, {
-          includeId: this.options.unstable_sendMessageIds,
+          unstable_includeId: this.options.unstable_sendMessageIds,
         }),
         tools: config.tools ? toLanguageModelTools(config.tools) : [],
         unstable_assistantMessageId,

--- a/packages/react/src/runtimes/edge/EdgeRuntimeRequestOptions.ts
+++ b/packages/react/src/runtimes/edge/EdgeRuntimeRequestOptions.ts
@@ -83,6 +83,7 @@ export const EdgeRuntimeRequestOptionsSchema = z
     system: z.string().optional(),
     messages: z.array(CoreMessageSchema).min(1),
     tools: z.array(LanguageModelV1FunctionToolSchema).optional(),
+    unstable_assistantMessageId: z.string().optional(),
   })
   .merge(LanguageModelV1CallSettingsSchema)
   .merge(LanguageModelConfigSchema);

--- a/packages/react/src/runtimes/edge/converters/toCoreMessages.ts
+++ b/packages/react/src/runtimes/edge/converters/toCoreMessages.ts
@@ -1,25 +1,21 @@
 import { ThreadMessage, CoreMessage } from "../../../types";
 
-type ToCoreMessageOptions = {
-  includeId?: boolean | undefined;
-};
-
-type CoreMessageWithConditionalId<T extends boolean> = T extends true
-  ? CoreMessage & { id?: string }
-  : CoreMessage;
+type CoreMessageWithConditionalId<T extends boolean> = T extends false
+  ? CoreMessage
+  : CoreMessage & { unstable_id?: string };
 
 export const toCoreMessages = <T extends boolean = false>(
   messages: ThreadMessage[],
-  options: ToCoreMessageOptions & { includeId?: T | undefined } = {},
+  options: { unstable_includeId?: T | undefined } = {},
 ): CoreMessageWithConditionalId<T>[] => {
   return messages.map((message) => toCoreMessage(message, options));
 };
 
 export const toCoreMessage = <T extends boolean = false>(
   message: ThreadMessage,
-  options: ToCoreMessageOptions & { includeId?: T | undefined } = {},
+  options: { unstable_includeId?: T | undefined } = {},
 ): CoreMessageWithConditionalId<T> => {
-  const includeId = options.includeId ?? false;
+  const includeId = options.unstable_includeId ?? false;
   const role = message.role;
   switch (role) {
     case "assistant":
@@ -33,7 +29,7 @@ export const toCoreMessage = <T extends boolean = false>(
           }
           return part;
         }),
-        ...(includeId ? { id: message.id } : {}),
+        ...(includeId ? { unstable_id: message.id } : {}),
       };
 
     case "user":
@@ -47,14 +43,14 @@ export const toCoreMessage = <T extends boolean = false>(
           }),
           ...message.attachments.map((a) => a.content).flat(),
         ],
-        ...(includeId ? { id: message.id } : {}),
+        ...(includeId ? { unstable_id: message.id } : {}),
       };
 
     case "system":
       return {
         role,
         content: message.content,
-        ...(includeId ? { id: message.id } : {}),
+        ...(includeId ? { unstable_id: message.id } : {}),
       };
 
     default: {

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -31,6 +31,8 @@ export type ChatModelRunOptions = {
   abortSignal: AbortSignal;
   config: ModelConfig;
 
+  unstable_assistantMessageId?: string;
+
   /**
    * @deprecated Declare the run function as an AsyncGenerator instead. This method will be removed in v0.6
    */

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -190,6 +190,7 @@ export class LocalThreadRuntimeCore
         abortSignal: this.abortController.signal,
         config: this.getModelConfig(),
         onUpdate: updateMessage,
+        unstable_assistantMessageId: message.id,
       });
 
       // handle async iterator for streaming results


### PR DESCRIPTION
Implements a method of accessing ids of existing messages and new messages from the server on the Edge Runtime. This enables the server to maintain a copy of a data structure compatible with the `.import(...)` function available on some runtimes.

This PR consists of three changes:
1. The LocalRuntime's `performRoundtrip` now supplies its chat adapter's `*run` async generator with `unstable_assistantMessageId`.
2. The Edge Runtime includes `unstable_assistantMessageId` in the body of the request it makes to the backend.
3. `useEdgeRuntime` now provides an `unstable_sendMessageIds` option. When enabled, the EdgeRuntime will not strip the `id` field from messages before sending them to the server.

Usage:
```
// within runtime provider
const runtime = useEdgeRuntime({
  api: "/api/chat",
  unstable_sendMessageIds: true,
});



// within server route handler
const {
  messages, // messages may contain an `id` if `unstable_sendMessageIds` is enabled on the frontend
  unstable_assistantMessageId: newMessageId, // the id of the message that is about to generate
  ...rest
} = await req.json();

...

// extract the latest message and the message it replies to
const userLatestMessage = messages.at(-1);
const previousMessage = messages.at(-2);

// store new user message
storeMessage({
  ...newUserMessage,
  parentId: previousMessage?.id
})

...

const assistantResponse = await getEdgeRuntimeResponse({
  options: {
    async onFinish(finishResult) {
      // extract the assistant's generated message
      const assistantGeneratedMessage = finishResult.messages.at(-1);
      
      // store new assistant message
      storeMessage({
        ...assistantGeneratedMessage,
        id: unstable_assistantMessageId,
        parentId: newUserMessage.id,
      })
    }
  }
});
...
```

This change was discussed on Discord before implementation:
https://discord.com/channels/1251324227668283443/1251754454139539547/1298767870469083178
