### PR TITLE
fix: updated Message.Root to MessagePrimitive.Root

### DIFF
--- a/apps/docs/content/docs/ui/primitives/Message.mdx
+++ b/apps/docs/content/docs/ui/primitives/Message.mdx
@@ -17,7 +17,7 @@ const UserMessage = () => (
 
     <BranchPicker />
     <ActionBar />
-  </Message.Root>
+  </MessagePrimitive.Root>
 );
 
 const AssistantMessage = () => (
@@ -26,7 +26,7 @@ const AssistantMessage = () => (
 
     <BranchPicker />
     <ActionBar />
-  </Message.Root>
+  </MessagePrimitive.Root>
 );
 ```
 


### PR DESCRIPTION
This pull request includes changes to the `apps/docs/content/docs/ui/primitives/Message.mdx` file to update component usage. The changes focus on replacing the `Message.Root` component with the `MessagePrimitive.Root` component for consistency and clarity.

Component updates:

* [`apps/docs/content/docs/ui/primitives/Message.mdx`](diffhunk://#diff-0ae1b77e502d79aac1dc194849457cf84e4307abab2b11f70f06e34aae4c3bfeL20-R20): Replaced `Message.Root` with `MessagePrimitive.Root` in the `UserMessage` component.
* [`apps/docs/content/docs/ui/primitives/Message.mdx`](diffhunk://#diff-0ae1b77e502d79aac1dc194849457cf84e4307abab2b11f70f06e34aae4c3bfeL29-R29): Replaced `Message.Root` with `MessagePrimitive.Root` in the `AssistantMessage` component.