### PR TITLE
feat: pass a string instead of an array content for text-only messages

### DIFF
--- a/.changeset/stupid-planets-ring.md
+++ b/.changeset/stupid-planets-ring.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: pass a string instead of an array content for text-only messages

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -8,6 +8,7 @@ import { convertLangchainMessages } from "./convertLangchainMessages";
 import { useLangGraphMessages } from "./useLangGraphMessages";
 import { SimpleImageAttachmentAdapter } from "@assistant-ui/react";
 import { AttachmentAdapter } from "@assistant-ui/react";
+import { AppendMessage } from "@assistant-ui/react";
 
 const getPendingToolCalls = (messages: LangChainMessage[]) => {
   const pendingToolCalls = new Map<string, LangChainToolCall>();
@@ -23,6 +24,37 @@ const getPendingToolCalls = (messages: LangChainMessage[]) => {
   }
 
   return [...pendingToolCalls.values()];
+};
+
+const getMessageContent = (msg: AppendMessage) => {
+  const allContent = [
+    ...msg.content,
+    ...msg.attachments.flatMap((a) => a.content),
+  ];
+  const content = allContent.map((part) => {
+    const type = part.type;
+    switch (type) {
+      case "text":
+        return { type: "text" as const, text: part.text };
+      case "image":
+        return { type: "image_url" as const, image_url: { url: part.image } };
+
+      case "audio":
+        throw new Error("Audio appends are not supported yet.");
+      case "tool-call":
+        throw new Error("Tool call appends are not supported yet.");
+
+      default:
+        const _exhaustiveCheck: never = type;
+        throw new Error(`Unknown content part type: ${_exhaustiveCheck}`);
+    }
+  });
+
+  if (content.length === 1 && content[0]!.type === "text") {
+    return content[0]!.text!;
+  }
+
+  return content;
 };
 
 export const useLangGraphRuntime = ({
@@ -120,35 +152,11 @@ export const useLangGraphRuntime = ({
             )
           : [];
 
-      const allContent = [
-        ...msg.content,
-        ...msg.attachments.flatMap((a) => a.content),
-      ];
-
       return handleSendMessage([
         ...cancellations,
         {
           type: "human",
-          content: allContent.map((part) => {
-            const type = part.type;
-            switch (type) {
-              case "text":
-                return { type: "text", text: part.text };
-              case "image":
-                return { type: "image_url", image_url: { url: part.image } };
-
-              case "audio":
-                throw new Error("Audio appends are not supported yet.");
-              case "tool-call":
-                throw new Error("Tool call appends are not supported yet.");
-
-              default:
-                const _exhaustiveCheck: never = type;
-                throw new Error(
-                  `Unknown content part type: ${_exhaustiveCheck}`,
-                );
-            }
-          }),
+          content: getMessageContent(msg),
         },
       ]);
     },

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -50,8 +50,8 @@ const getMessageContent = (msg: AppendMessage) => {
     }
   });
 
-  if (content.length === 1 && content[0]!.type === "text") {
-    return content[0]!.text!;
+  if (content.length === 1 && content[0]?.type === "text") {
+    return content[0].text ?? "";
   }
 
   return content;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users can now pass a string instead of an array for text-only messages in the `@assistant-ui/react-langgraph` package, simplifying message input.
  
- **Bug Fixes**
	- Improved error handling for unsupported audio and tool-call types in message processing, ensuring only valid content types are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->