### PR TITLE
Fix SyntaxError: f-string: unmatched '{' error

### DIFF
--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -15,11 +15,11 @@ class DataStreamEncoder(StreamEncoder):
         if chunk.type == "text-delta":
             return f"0:{json.dumps(chunk.text_delta)}\n"
         elif chunk.type == "tool-call-begin":
-            return f"b:{json.dumps({ "toolCallId": chunk.tool_call_id, "toolName": chunk.tool_name })}\n"
+            return f'b:{json.dumps({ "toolCallId": chunk.tool_call_id, "toolName": chunk.tool_name })}\n'
         elif chunk.type == "tool-call-delta":
-            return f"c:{json.dumps({ "toolCallId": chunk.tool_call_id, "argsTextDelta": chunk.args_text_delta })}\n"
+            return f'c:{json.dumps({ "toolCallId": chunk.tool_call_id, "argsTextDelta": chunk.args_text_delta })}\n'
         elif chunk.type == "tool-result":
-            return f"a:{json.dumps({ "toolCallId": chunk.tool_call_id, "result": chunk.result })}\n"
+            return f'a:{json.dumps({ "toolCallId": chunk.tool_call_id, "result": chunk.result })}\n'
         pass
 
     def get_media_type(self) -> str:


### PR DESCRIPTION
# 🔍 Review Summary 
 **Purpose**: 
- This update resolves a SyntaxError in the `encode_chunk` method to prevent runtime errors.

**Changes**:
- **Bug Fix**: Adjusted f-string expressions in `data_stream.py` for accurate JSON data formatting.

**Impact**:
- Enhances system reliability by removing a potential runtime error source. 



<details><summary>Original Description</summary>

No existing description found

</details>