### PR TITLE
fix: react warning about unsupported prop

### DIFF
--- a/.changeset/poor-eyes-jump.md
+++ b/.changeset/poor-eyes-jump.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-markdown": patch
+---
+
+fix: react warning about unsupported prop

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -76,20 +76,29 @@ export type CodeOverrideProps = ComponentPropsWithoutRef<CodeComponent> & {
     CodeHeader: ComponentType<CodeHeaderProps>;
     SyntaxHighlighter: ComponentType<SyntaxHighlighterProps>;
   };
-  componentsByLanguage?: Record<
-    string,
-    {
-      CodeHeader?: ComponentType<CodeHeaderProps>;
-      SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps>;
-    }
-  >;
+  componentsByLanguage?:
+    | Record<
+        string,
+        {
+          CodeHeader?: ComponentType<CodeHeaderProps>;
+          SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps>;
+        }
+      >
+    | undefined;
 };
 
 export const CodeOverride: FC<CodeOverrideProps> = ({
   components,
+  componentsByLanguage,
   ...props
 }) => {
   const preProps = useContext(PreContext);
   if (!preProps) return <components.Code {...props} />;
-  return <CodeBlockOverride components={components} {...props} />;
+  return (
+    <CodeBlockOverride
+      components={components}
+      componentsByLanguage={componentsByLanguage}
+      {...props}
+    />
+  );
 };


### PR DESCRIPTION
# 🔍 Review Summary 
 **Purpose**:
- Addressed a React warning by improving the handling of optional properties.

**Changes**:
- **Bug Fix**: Updated the `CodeOverride` component to properly manage the `componentsByLanguage` prop, eliminating React warnings about unsupported props.

**Impact**:
- Improved codebase maintainability by resolving unnecessary warnings and enhancing prop management in the `CodeOverride` component. 



<details><summary>Original Description</summary>

fixes #1265

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved a React warning related to an unsupported property in the markdown component.
  
- **New Features**
	- Enhanced type safety for the `componentsByLanguage` property in the `CodeOverride` component, now explicitly allowing `undefined`.
	- Improved prop forwarding in the `CodeOverride` component to ensure correct functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->