### PR TITLE
fix: ComposerRuntime.send() should not reset role or runConfig

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.2"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.23",
+    "@assistant-ui/react": "^0.7.24",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.23",
+    "@assistant-ui/react": "^0.7.24",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.23",
+    "@assistant-ui/react": "^0.7.24",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -41,7 +41,7 @@
     "react-markdown": "^9.0.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.23",
+    "@assistant-ui/react": "^0.7.24",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -47,7 +47,7 @@
     "zustand": "^5.0.2"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.23",
+    "@assistant-ui/react": "^0.7.24",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.23",
+    "@assistant-ui/react": "^0.7.24",
     "@assistant-ui/react-markdown": "^0.7.7",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react-trieve/package.json
+++ b/packages/react-trieve/package.json
@@ -45,7 +45,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.23",
+    "@assistant-ui/react": "^0.7.24",
     "@assistant-ui/react-markdown": "^0.7.7",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.7.24
+
+### Patch Changes
+
+- fix: ComposerRuntime.send() should not reset role or runConfig
+
 ## 0.7.23
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.23",
+  "version": "0.7.24",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react/src/runtimes/composer/BaseComposerRuntimeCore.tsx
+++ b/packages/react/src/runtimes/composer/BaseComposerRuntimeCore.tsx
@@ -78,17 +78,33 @@ export abstract class BaseComposerRuntimeCore implements ComposerRuntimeCore {
     this.notifySubscribers();
   }
 
-  private _resetInternal() {
+  private _sendOrReset() {
     // TODO attachmentAdapter.remove should be called here
     this._attachments = [];
     this._text = "";
-    this._role = "user";
-    this._runConfig = {};
     this.notifySubscribers();
   }
 
   public async reset() {
-    return this._resetInternal();
+    if (
+      this._attachments.length === 0 &&
+      this._text === "" &&
+      this._role === "user" &&
+      Object.keys(this._runConfig).length === 0
+    ) {
+      return;
+    }
+
+    const attachments = this._attachments;
+    this._role = "user";
+    this._runConfig = {};
+
+    this._sendOrReset();
+
+    const adapter = this.getAttachmentAdapter();
+    if (adapter) {
+      await Promise.all(attachments.map((a) => adapter.remove(a)));
+    }
   }
 
   public async send() {
@@ -110,7 +126,7 @@ export abstract class BaseComposerRuntimeCore implements ComposerRuntimeCore {
       attachments,
       runConfig: this.runConfig,
     };
-    this._resetInternal();
+    this._sendOrReset();
 
     this.handleSend(message);
     this._notifyEventSubscribers("send");

--- a/packages/react/src/runtimes/composer/BaseComposerRuntimeCore.tsx
+++ b/packages/react/src/runtimes/composer/BaseComposerRuntimeCore.tsx
@@ -79,7 +79,6 @@ export abstract class BaseComposerRuntimeCore implements ComposerRuntimeCore {
   }
 
   private _sendOrReset() {
-    // TODO attachmentAdapter.remove should be called here
     this._attachments = [];
     this._text = "";
     this.notifySubscribers();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed `ComposerRuntime.send()` method to prevent unintended resetting of `role` and `runConfig`

- **Chores**
	- Updated peer dependency version for `@assistant-ui/react` across multiple packages from `^0.7.23` to `^0.7.24`
	- Bumped package version to `0.7.24`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->