### PR TITLE
feat: allow calling ThreadList methods via threadId or remoteId and use remoteId in adapter

### DIFF
--- a/packages/react/src/runtimes/core/ThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadListRuntimeCore.tsx
@@ -3,7 +3,7 @@ import { ThreadRuntimeCore } from "./ThreadRuntimeCore";
 
 type ThreadListItemCoreState = {
   readonly threadId: string;
-  readonly remoteId?: string;
+  readonly remoteId?: string | undefined;
 
   readonly status: "archived" | "regular" | "new" | "deleted";
   readonly title?: string | undefined;

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -36,21 +36,24 @@ type RemoteThreadState = {
   readonly threadData: Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
 };
 
-const getThreadData = (state: RemoteThreadState, threadId: string) => {
-  const idx = state.threadIdMap[threadId];
+const getThreadData = (
+  state: RemoteThreadState,
+  threadIdOrRemoteId: string,
+) => {
+  const idx = state.threadIdMap[threadIdOrRemoteId];
   if (idx === undefined) return undefined;
   return state.threadData[idx];
 };
 
 const updateStatusReducer = (
   state: RemoteThreadState,
-  threadId: string,
+  threadIdOrRemoteId: string,
   newStatus: "regular" | "archived" | "deleted",
 ) => {
-  const data = getThreadData(state, threadId);
+  const data = getThreadData(state, threadIdOrRemoteId);
   if (!data) return state;
 
-  const { remoteId, status: lastStatus } = data;
+  const { threadId, remoteId, status: lastStatus } = data;
   if (lastStatus === newStatus) return state;
 
   const newState = { ...state };
@@ -257,7 +260,7 @@ export class RemoteThreadListThreadListRuntimeCore
       task.then(() => this._notifySubscribers());
     }
 
-    if (data.status === "archived") void this.unarchive(data.threadId);
+    if (data.status === "archived") await this.unarchive(data.threadId);
     this._mainThreadId = data.threadId;
 
     this._notifySubscribers();

--- a/packages/react/src/runtimes/remote-thread-list/types.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/types.tsx
@@ -18,7 +18,7 @@ export type RemoteThreadListAdapter = {
 
   list(): Promise<RemoteThreadListResponse>;
 
-  rename(remoteId: string, newName: string): Promise<void>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
   archive(remoteId: string): Promise<void>;
   unarchive(remoteId: string): Promise<void>;
   delete(remoteId: string): Promise<void>;

--- a/packages/react/src/runtimes/remote-thread-list/types.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/types.tsx
@@ -18,10 +18,10 @@ export type RemoteThreadListAdapter = {
 
   list(): Promise<RemoteThreadListResponse>;
 
-  rename(threadId: string, newName: string): Promise<void>;
-  archive(threadId: string): Promise<void>;
-  unarchive(threadId: string): Promise<void>;
-  delete(threadId: string): Promise<void>;
+  rename(remoteId: string, newName: string): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
 
   onInitialize(
     callback: (task: Promise<{ remoteId: string }>) => Promise<void>,


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Release Note

**Purpose**:
- Enhance thread management with a flexible identifier mapping mechanism.

**Changes**:

- **Enhancement**: 
  - Introduced `THREAD_MAPPING_ID` and `createThreadMappingId` for operations using `threadId` or `remoteId`.

- **Modification**: 
  - Updated `ThreadListItemCoreState` and `RemoteThreadListAdapter` to support `remoteId`, improving data management.

**Impact**:
- Improved adaptability and flexibility in handling thread identifiers, enhancing performance and usability in remote contexts. 



<details><summary>Original Description</summary>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Type Safety Improvements**
	- Enhanced type definitions for thread-related data structures
	- Updated method signatures to use more precise parameter naming
	- Introduced more explicit type handling for thread identifiers

- **Technical Refinements**
	- Improved type definitions for remote thread management
	- Standardized terminology for thread identification methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

</details>