### PR TITLE
fix: AttachmentRemove should not trigger AttachmentPreviewDialog

### DIFF
--- a/.changeset/moody-lizards-beam.md
+++ b/.changeset/moody-lizards-beam.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: AttachmentRemove should not trigger AttachmentPreviewDialog

--- a/packages/react/src/styles/tailwindcss/thread.css
+++ b/packages/react/src/styles/tailwindcss/thread.css
@@ -73,7 +73,11 @@
 /* attachment */
 
 .aui-attachment-root {
-  @apply relative mt-3 flex h-12 w-40 items-center justify-center gap-2 rounded-lg border p-1;
+  @apply relative mt-3;
+}
+
+.aui-attachment-content {
+  @apply flex h-12 w-40 items-center justify-center gap-2 rounded-lg border p-1;
 }
 
 .aui-attachment-preview-trigger {

--- a/packages/react/src/ui/attachment-ui.tsx
+++ b/packages/react/src/ui/attachment-ui.tsx
@@ -29,6 +29,10 @@ const AttachmentRoot = withDefaults(AttachmentPrimitive.Root, {
   className: "aui-attachment-root",
 });
 
+const AttachmentContent = withDefaults("div", {
+  className: "aui-attachment-content",
+});
+
 AttachmentRoot.displayName = "AttachmentRoot";
 
 const useFileSrc = (file: File | undefined) => {
@@ -141,20 +145,22 @@ const AttachmentUI: FC = () => {
   });
   return (
     <Tooltip>
-      <AttachmentPreviewDialog>
-        <TooltipTrigger asChild>
-          <AttachmentRoot>
-            <AttachmentThumb />
-            <div className="aui-attachment-text">
-              <p className="aui-attachment-name">
-                <AttachmentPrimitive.Name />
-              </p>
-              <p className="aui-attachment-type">{typeLabel}</p>
-            </div>
-            {canRemove && <AttachmentRemove />}
-          </AttachmentRoot>
-        </TooltipTrigger>
-      </AttachmentPreviewDialog>
+      <AttachmentRoot>
+        <AttachmentPreviewDialog>
+          <TooltipTrigger asChild>
+            <AttachmentContent>
+              <AttachmentThumb />
+              <div className="aui-attachment-text">
+                <p className="aui-attachment-name">
+                  <AttachmentPrimitive.Name />
+                </p>
+                <p className="aui-attachment-type">{typeLabel}</p>
+              </div>
+            </AttachmentContent>
+          </TooltipTrigger>
+        </AttachmentPreviewDialog>
+        {canRemove && <AttachmentRemove />}
+      </AttachmentRoot>
       <TooltipContent side="top">
         <AttachmentPrimitive.Name />
       </TooltipContent>

--- a/packages/react/src/utils/createActionButton.tsx
+++ b/packages/react/src/utils/createActionButton.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { ElementRef, forwardRef, ComponentPropsWithoutRef } from "react";
+import {
+  ElementRef,
+  forwardRef,
+  ComponentPropsWithoutRef,
+  MouseEventHandler,
+} from "react";
 import { Primitive } from "@radix-ui/react-primitive";
 import { composeEventHandlers } from "@radix-ui/primitive";
 
-type ActionButtonCallback<TProps> = (props: TProps) => null | (() => void);
+type ActionButtonCallback<TProps> = (
+  props: TProps,
+) => MouseEventHandler<HTMLButtonElement> | null;
 
 type PrimitiveButtonProps = ComponentPropsWithoutRef<typeof Primitive.button>;
 
@@ -33,16 +40,14 @@ export const createActionButton = <TProps,>(
       }
     });
 
-    const callback = useActionButton(forwardedProps as TProps);
+    const callback = useActionButton(forwardedProps as TProps) ?? undefined;
     return (
       <Primitive.button
         type="button"
         {...primitiveProps}
         ref={forwardedRef}
         disabled={primitiveProps.disabled || !callback}
-        onClick={composeEventHandlers(primitiveProps.onClick, () => {
-          callback?.();
-        })}
+        onClick={composeEventHandlers(primitiveProps.onClick, callback)}
       />
     );
   });


### PR DESCRIPTION
# 🔍 Review Summary 
 ### Release Note

**Purpose**:
- Address a bug in the `AttachmentRemove` component, enhance UI structure, refine utilities, and ensure style consistency.

**Changes**:

- **Bug Fix**: 
  - Fixed the `AttachmentRemove` component issue that triggered the `AttachmentPreviewDialog` incorrectly.

- **Refactor**: 
  - Restructured UI components for improved maintainability and separation of concerns.

- **Enhancement**: 
  - Enhanced the `createActionButton` utility for better mouse event handling.

- **Style**: 
  - Applied CSS adjustments for consistent styling across attachment components.

- **Documentation**: 
  - Updated changeset to document the bug fix in the `AttachmentRemove` component.

**Impact**:
- Enhances user interaction by resolving component malfunctions, improving interface responsivity, and ensuring a consistent visual experience. 



<details><summary>Original Description</summary>

None

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with attachment removal functionality to prevent unintended preview dialog opening.

- **Style**
	- Updated CSS classes for attachment components to improve styling and structure.
	- Refined attachment component layout and visual presentation.

- **Refactor**
	- Improved type definitions and event handling for action buttons.
	- Introduced a new `AttachmentContent` component for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->