### PR TITLE
feat(langgraph): interrupt + Command support

### DIFF
--- a/.changeset/few-clocks-collect.md
+++ b/.changeset/few-clocks-collect.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: manually trigger langgraph sends via useLangGraphRuntimeSend

--- a/.changeset/little-students-smash.md
+++ b/.changeset/little-students-smash.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: support for Command

--- a/.changeset/tough-lions-prove.md
+++ b/.changeset/tough-lions-prove.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: interrupt+Command support via useLangGraphRuntimeSendCommand

--- a/packages/react-langgraph/src/index.ts
+++ b/packages/react-langgraph/src/index.ts
@@ -1,4 +1,8 @@
-export { useLangGraphRuntime } from "./useLangGraphRuntime";
+export {
+  useLangGraphRuntime,
+  useLangGraphRuntimeSend,
+  useLangGraphRuntimeSendCommand,
+} from "./useLangGraphRuntime";
 
 export { useLangGraphMessages } from "./useLangGraphMessages";
 export { convertLangchainMessages } from "./convertLangchainMessages";

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -7,7 +7,7 @@ export type LangGraphCommand = {
   resume: string;
 };
 
-export type LangGraphStreamConfig = {
+export type LangGraphSendMessageConfig = {
   command?: LangGraphCommand;
   runConfig?: unknown;
 };
@@ -17,7 +17,7 @@ export const useLangGraphMessages = <TMessage>({
 }: {
   stream: (
     messages: TMessage[],
-    config: LangGraphStreamConfig,
+    config: LangGraphSendMessageConfig,
   ) => Promise<
     AsyncGenerator<{
       event: string;
@@ -28,7 +28,7 @@ export const useLangGraphMessages = <TMessage>({
   const [messages, setMessages] = useState<TMessage[]>([]);
 
   const sendMessage = useCallback(
-    async (newMessages: TMessage[], config: LangGraphStreamConfig) => {
+    async (newMessages: TMessage[], config: LangGraphSendMessageConfig) => {
       const optimisticMessages = [...messages, ...newMessages];
       if (newMessages.length > 0) {
         setMessages(optimisticMessages);

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -3,10 +3,22 @@ import { INTERNAL } from "@assistant-ui/react";
 
 const { generateId } = INTERNAL;
 
+export type LangGraphCommand = {
+  resume: string;
+};
+
+export type LangGraphStreamConfig = {
+  command?: LangGraphCommand;
+  runConfig?: unknown;
+};
+
 export const useLangGraphMessages = <TMessage>({
   stream,
 }: {
-  stream: (messages: TMessage[]) => Promise<
+  stream: (
+    messages: TMessage[],
+    config: LangGraphStreamConfig,
+  ) => Promise<
     AsyncGenerator<{
       event: string;
       data: any;
@@ -16,13 +28,13 @@ export const useLangGraphMessages = <TMessage>({
   const [messages, setMessages] = useState<TMessage[]>([]);
 
   const sendMessage = useCallback(
-    async (newMessages: TMessage[]) => {
+    async (newMessages: TMessage[], config: LangGraphStreamConfig) => {
       const optimisticMessages = [...messages, ...newMessages];
       if (newMessages.length > 0) {
         setMessages(optimisticMessages);
       }
 
-      const response = await stream(newMessages);
+      const response = await stream(newMessages, config);
 
       const completeMessages: TMessage[] = [];
       let partialMessages: Map<string, TMessage> = new Map();


### PR DESCRIPTION
# 🔍 Review Summary 
 **Purpose**:
- Enhance `react-langgraph` usability with improved messaging flow controls and updated streaming capabilities.

**Changes**:
- **Enhancement**: Implemented command and interrupt support via `useLangGraphRuntimeSendCommand` for complex message handling.
- **New Feature**: Introduced manual triggering of sends with `useLangGraphRuntimeSend` for better control.
- **Enhancement**: Updated message streaming to support flexible command and runtime configurations.

**Impact**:
- Provides users with greater control and flexibility, enhancing user experience and package capability. 



<details><summary>Original Description</summary>

None

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced runtime message handling with new configuration options
	- Added support for sending commands and messages with extended configuration
	- Introduced new methods for more flexible message interactions in the LangGraph runtime

- **Improvements**
	- Expanded API to provide more granular control over message streaming
	- Updated function signatures to support additional configuration parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->