### PR TITLE
feat: useAssistantInstructions disable support

### DIFF
--- a/.changeset/strange-turtles-act.md
+++ b/.changeset/strange-turtles-act.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: useAssistantInstructions disable support

--- a/packages/react/src/model-config/useAssistantInstructions.tsx
+++ b/packages/react/src/model-config/useAssistantInstructions.tsx
@@ -3,9 +3,27 @@
 import { useEffect } from "react";
 import { useAssistantRuntime } from "../context";
 
-export const useAssistantInstructions = (instruction: string) => {
+type AssistantInstructionsConfig = {
+  disabled?: boolean | undefined;
+  instruction: string;
+};
+
+const getInstructions = (
+  instruction: string | AssistantInstructionsConfig,
+): AssistantInstructionsConfig => {
+  if (typeof instruction === "string") return { instruction };
+  return instruction;
+};
+
+export const useAssistantInstructions = (
+  config: string | AssistantInstructionsConfig,
+) => {
+  const { instruction, disabled = false } = getInstructions(config);
   const assistantRuntime = useAssistantRuntime();
+
   useEffect(() => {
+    if (disabled) return;
+
     const config = {
       system: instruction,
     };


### PR DESCRIPTION
# 🔍 Review Summary 
 The `useAssistantInstructions` hook now supports a configuration object with a `disabled` flag, allowing for conditional disabling of instructions. This update is documented in a new changeset file. 



<details><summary>Original Description</summary>

None

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `useAssistantInstructions` hook with more flexible configuration options
	- Added support for disabling assistant instructions
	- Introduced a new configuration type for more structured input handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->