### PR TITLE
feat: ExternalStoreAdapter.unstable_Provider

### DIFF
--- a/.changeset/clean-files-film.md
+++ b/.changeset/clean-files-film.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-playground": patch
+"@assistant-ui/react": patch
+---
+
+feat: ExternalStoreAdapter.unstable_Provider

--- a/packages/react-playground/src/lib/playground-runtime.ts
+++ b/packages/react-playground/src/lib/playground-runtime.ts
@@ -134,6 +134,7 @@ class PlaygroundThreadListRuntimeCore
 
 class PlaygroundRuntimeCore extends BaseAssistantRuntimeCore {
   public readonly threadList;
+  public readonly Provider = undefined;
 
   constructor(
     adapter: ChatModelAdapter,

--- a/packages/react/src/context/providers/AssistantRuntimeProvider.tsx
+++ b/packages/react/src/context/providers/AssistantRuntimeProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC, PropsWithChildren } from "react";
-import { memo, useEffect, useMemo, useState } from "react";
+import { Fragment, memo, useEffect, useMemo, useState } from "react";
 import { AssistantContext } from "../react/AssistantContext";
 import { makeAssistantToolUIsStore } from "../stores/AssistantToolUIs";
 import { ThreadRuntimeProvider } from "./ThreadRuntimeProvider";
@@ -46,13 +46,9 @@ const useThreadListStore = (runtime: AssistantRuntime) => {
   return store;
 };
 
-const DEFAULT_RENDER_COMPONENT: FC<PropsWithChildren> = ({ children }) =>
-  children;
-
 const getRenderComponent = (runtime: AssistantRuntime) => {
   return (
-    (runtime as { _core?: AssistantRuntimeCore })._core
-      ?.__internal_RenderComponent ?? DEFAULT_RENDER_COMPONENT
+    (runtime as { _core?: AssistantRuntimeCore })._core?.Provider ?? Fragment
   );
 };
 

--- a/packages/react/src/runtimes/core/AssistantRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/AssistantRuntimeCore.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import { ComponentType, PropsWithChildren } from "react";
 import type { ModelConfigProvider } from "../../types/ModelConfigTypes";
 import type { Unsubscribe } from "../../types/Unsubscribe";
 import { ThreadListRuntimeCore } from "./ThreadListRuntimeCore";
@@ -15,5 +15,5 @@ export type AssistantRuntimeCore = {
    * Refer to the source implementation of `ExternalStoreRuntimeCore`
    * for an example of updating the provider via a zustand store.
    */
-  readonly Provider: React.FC<PropsWithChildren> | undefined;
+  readonly Provider: ComponentType<PropsWithChildren> | undefined;
 };

--- a/packages/react/src/runtimes/core/AssistantRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/AssistantRuntimeCore.tsx
@@ -8,5 +8,12 @@ export type AssistantRuntimeCore = {
 
   registerModelConfigProvider: (provider: ModelConfigProvider) => Unsubscribe;
 
-  __internal_RenderComponent?: React.FC<PropsWithChildren>;
+  /**
+   * A Provider component that wraps the app via `AssistantRuntimeProvider`.
+   *
+   * Note: This field is expected to never change.
+   * Refer to the source implementation of `ExternalStoreRuntimeCore`
+   * for an example of updating the provider via a zustand store.
+   */
+  readonly Provider: React.FC<PropsWithChildren> | undefined;
 };

--- a/packages/react/src/runtimes/core/BaseAssistantRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/BaseAssistantRuntimeCore.tsx
@@ -7,6 +7,7 @@ import { ThreadListRuntimeCore } from "./ThreadListRuntimeCore";
 export abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
   protected readonly _proxyConfigProvider = new ProxyConfigProvider();
   public abstract get threadList(): ThreadListRuntimeCore;
+  public abstract get Provider(): React.FC<React.PropsWithChildren> | undefined;
 
   constructor() {}
 

--- a/packages/react/src/runtimes/core/BaseAssistantRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/BaseAssistantRuntimeCore.tsx
@@ -3,11 +3,14 @@ import type { Unsubscribe } from "../../types/Unsubscribe";
 import type { AssistantRuntimeCore } from "./AssistantRuntimeCore";
 import { ProxyConfigProvider } from "../../utils/ProxyConfigProvider";
 import { ThreadListRuntimeCore } from "./ThreadListRuntimeCore";
+import { ComponentType } from "react";
 
 export abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
   protected readonly _proxyConfigProvider = new ProxyConfigProvider();
   public abstract get threadList(): ThreadListRuntimeCore;
-  public abstract get Provider(): React.FC<React.PropsWithChildren> | undefined;
+  public abstract get Provider():
+    | ComponentType<React.PropsWithChildren>
+    | undefined;
 
   constructor() {}
 

--- a/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
@@ -89,6 +89,11 @@ export type ThreadRuntimeCore = Readonly<{
   isDisabled: boolean;
   messages: readonly ThreadMessage[];
   suggestions: readonly ThreadSuggestion[];
+
+  /**
+   * @deprecated This field is deprecated and will be removed in 0.8.0.
+   * Please migrate to using `AssistantRuntimeCore.Provider` instead.
+   */
   extras: unknown;
 
   subscribe: (callback: () => void) => Unsubscribe;

--- a/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from "react";
 import { AppendMessage, ThreadMessage } from "../../types";
 import { AttachmentAdapter } from "../attachment";
 import {
@@ -53,6 +54,11 @@ type ExternalStoreAdapterBase<T> = {
   isRunning?: boolean | undefined;
   messages: T[];
   suggestions?: readonly ThreadSuggestion[] | undefined;
+
+  /**
+   * @deprecated This field is deprecated and will be removed in 0.8.0. 
+   * Please migrate to `Provider` and a custom react context provider component instead.
+   */
   extras?: unknown;
 
   setMessages?: ((messages: T[]) => void) | undefined;
@@ -82,6 +88,8 @@ type ExternalStoreAdapterBase<T> = {
         copy?: boolean | undefined;
       }
     | undefined;
+
+  unstable_Provider?: React.ComponentType<PropsWithChildren> | undefined;
 };
 
 export type ExternalStoreAdapter<T = ThreadMessage> =

--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -80,10 +80,10 @@ export class ExternalStoreThreadRuntimeCore
     store: ExternalStoreAdapter<any>,
   ) {
     super(configProvider);
-    this.__internal_setStore(store);
+    this.__internal_setAdapter(store);
   }
 
-  public __internal_setStore(store: ExternalStoreAdapter<any>) {
+  public __internal_setAdapter(store: ExternalStoreAdapter<any>) {
     if (this._store === store) return;
 
     const isRunning = store.isRunning ?? false;

--- a/packages/react/src/runtimes/external-store/useExternalStoreRuntime.tsx
+++ b/packages/react/src/runtimes/external-store/useExternalStoreRuntime.tsx
@@ -8,7 +8,7 @@ export const useExternalStoreRuntime = <T,>(store: ExternalStoreAdapter<T>) => {
   const [runtime] = useState(() => new ExternalStoreRuntimeCore(store));
 
   useEffect(() => {
-    runtime.setStore(store);
+    runtime.setAdapter(store);
   });
 
   return useMemo(

--- a/packages/react/src/runtimes/local/LocalRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalRuntimeCore.tsx
@@ -20,6 +20,7 @@ const getExportFromInitialMessages = (
 
 export class LocalRuntimeCore extends BaseAssistantRuntimeCore {
   public readonly threadList;
+  public readonly Provider = undefined;
 
   private _options: LocalRuntimeOptionsBase;
 

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -5,7 +5,7 @@ import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInsta
 import { BaseSubscribable } from "./BaseSubscribable";
 import { EMPTY_THREAD_CORE } from "./EMPTY_THREAD_CORE";
 import { OptimisticState } from "./OptimisticState";
-import { FC, PropsWithChildren, useEffect, useId } from "react";
+import { FC, Fragment, PropsWithChildren, useEffect, useId } from "react";
 import { create } from "zustand";
 import { CloudInitializeResponse } from "./cloud/CloudContext";
 
@@ -24,10 +24,6 @@ type RemoteThreadData =
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
     };
-
-const DEFAULT_RENDER_COMPONENT: FC<PropsWithChildren> = ({ children }) => {
-  return children;
-};
 
 type THREAD_MAPPING_ID = string & { __brand: "THREAD_MAPPING_ID" };
 function createThreadMappingId(id: string): THREAD_MAPPING_ID {
@@ -157,8 +153,7 @@ export class RemoteThreadListThreadListRuntimeCore
       adapter.runtimeHook,
     );
     this.useRenderComponent = create(() => ({
-      RenderComponent:
-        adapter.__internal_RenderComponent ?? DEFAULT_RENDER_COMPONENT,
+      RenderComponent: adapter.unstable_Provider ?? Fragment,
     }));
     this.__internal_setAdapter(adapter);
 
@@ -234,8 +229,7 @@ export class RemoteThreadListThreadListRuntimeCore
     this._disposeOldAdapter?.();
     this._disposeOldAdapter = this._adapter.onInitialize(this._onInitialize);
 
-    const RenderComponent =
-      adapter.__internal_RenderComponent ?? DEFAULT_RENDER_COMPONENT;
+    const RenderComponent = adapter.unstable_Provider ?? Fragment;
     if (
       RenderComponent !== this.useRenderComponent.getState().RenderComponent
     ) {
@@ -460,7 +454,7 @@ export class RemoteThreadListThreadListRuntimeCore
 
   private useBoundIds = create<string[]>(() => []);
 
-  public __internal_RenderComponent: FC<PropsWithChildren> = ({ children }) => {
+  public __internal_Provider: FC<PropsWithChildren> = ({ children }) => {
     const id = useId();
     useEffect(() => {
       this.useBoundIds.setState((s) => [...s, id], true);

--- a/packages/react/src/runtimes/remote-thread-list/cloud/useCloudThreadListRuntime.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/cloud/useCloudThreadListRuntime.tsx
@@ -86,8 +86,7 @@ export const useCloudThreadListRuntime = (adapter: CloudThreadListAdapter) => {
     onInitialize: (callback) => {
       return cloudContextValue.subscribe(callback);
     },
-    __internal_RenderComponent: ({ children }: PropsWithChildren) => {
-      console.log("RENDER COMPONENT");
+    unstable_Provider: ({ children }: PropsWithChildren) => {
       return (
         <CloudContext.Provider value={cloudContextValue}>
           {children}

--- a/packages/react/src/runtimes/remote-thread-list/types.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/types.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from "react";
+import { ComponentType, PropsWithChildren } from "react";
 import { AssistantRuntime } from "../../api";
 import { Unsubscribe } from "../../types";
 import { CloudInitializeResponse } from "./cloud/CloudContext";
@@ -30,5 +30,5 @@ export type RemoteThreadListAdapter = {
     callback: (task: Promise<CloudInitializeResponse>) => Promise<void>,
   ): Unsubscribe;
 
-  __internal_RenderComponent?: FC<PropsWithChildren>;
+  unstable_Provider?: ComponentType<PropsWithChildren>;
 };

--- a/packages/react/src/runtimes/remote-thread-list/useRemoteThreadListRuntime.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/useRemoteThreadListRuntime.tsx
@@ -12,8 +12,8 @@ class RemoteThreadListRuntimeCore extends BaseAssistantRuntimeCore {
     this.threadList = new RemoteThreadListThreadListRuntimeCore(adapter);
   }
 
-  public get __internal_RenderComponent() {
-    return this.threadList.__internal_RenderComponent;
+  public get Provider() {
+    return this.threadList.__internal_Provider;
   }
 }
 


### PR DESCRIPTION
None

---
# EntelligenceAI PR Summary 
 **Purpose**: Introduce flexible provider components for enhanced runtime flexibility and maintainability.

**Changes**:

- **New Feature**: Added `ExternalStoreAdapter.unstable_Provider` for custom provider components.

- **Refactor**: Streamlined code in `AssistantRuntimeCore.tsx`, `RemoteThreadListThreadListRuntimeCore.tsx`, `ExternalStoreRuntimeCore.tsx`, and `BaseAssistantRuntimeCore.tsx` for improved integration.

- **Enhancement**: Updated `Provider` state management using `zustand` and replaced deprecated fields in `ExternalStoreRuntimeCore.tsx`.

**Impact**: Enhances runtime flexibility, promotes modularity, and improves integration and maintainability. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `Provider` property across various runtime cores to support more flexible component rendering
  - Added support for custom rendering components in external store adapters

- **Deprecations**
  - Marked `extras` field as deprecated in some runtime types, recommending migration to `AssistantRuntimeCore.Provider`

- **Improvements**
  - Streamlined rendering logic by using React `Fragment` as a default provider
  - Enhanced type flexibility for runtime component providers

- **Changes**
  - Renamed several internal methods and properties related to rendering and store management
  - Updated type definitions to support more generic component types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->