### PR TITLE
feat: assistant-stream data chunk support

### DIFF
--- a/python/assistant-stream/poetry.lock
+++ b/python/assistant-stream/poetry.lock
@@ -63,13 +63,13 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.41.0"
+version = "0.44.0"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.41.0-py3-none-any.whl", hash = "sha256:a0193a3c413ebc9c78bff1c3546a45bb8c8bcb4a84cae8747d650a65bd37210a"},
-    {file = "starlette-0.41.0.tar.gz", hash = "sha256:39cbd8768b107d68bfe1ff1672b38a2c38b49777de46d2a592841d58e3bf7c2a"},
+    {file = "starlette-0.44.0-py3-none-any.whl", hash = "sha256:19edeb75844c16dcd4f9dd72f22f9108c1539f3fc9c4c88885654fef64f85aea"},
+    {file = "starlette-0.44.0.tar.gz", hash = "sha256:e35166950a3ccccc701962fe0711db0bc14f2ecd37c6f9fe5e3eae0cbaea8715"},
 ]
 
 [package.dependencies]
@@ -77,7 +77,7 @@ anyio = ">=3.4.0,<5"
 typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "typing-extensions"

--- a/python/assistant-stream/pyproject.toml
+++ b/python/assistant-stream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "assistant-stream"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
   { name="Simon Farshid", email="simon@assistant-ui.com" },
 ]
@@ -22,7 +22,7 @@ Issues = "https://github.com/Yonom/assistant-ui/issues"
 
 [tool.poetry]
 name = "assistant-stream"
-version = "0.0.6"
+version = "0.0.7"
 description = ""
 authors = ["Simon Farshid <simon@assistant-ui.com>"]
 

--- a/python/assistant-stream/src/assistant_stream/assistant_stream_chunk.py
+++ b/python/assistant-stream/src/assistant_stream/assistant_stream_chunk.py
@@ -5,31 +5,38 @@ from typing import Any, Union
 # Define the data classes for different chunk types
 @dataclass
 class TextDeltaChunk:
-    type: str  # "text-delta"
+    type: str = "text-delta"
     text_delta: str
+
 
 @dataclass
 class ToolCallBeginChunk:
-    type: str  # "tool-call-begin"
+    type: str = "tool-call-begin"
     tool_call_id: str
     tool_name: str
 
+
 @dataclass
 class ToolCallDeltaChunk:
-    type: str  # "tool-call-delta"
+    type: str = "tool-call-delta"
     tool_call_id: str
     args_text_delta: str
 
+
 @dataclass
 class ToolResultChunk:
-    type: str  # "tool-result"
+    type: str = "tool-result"
     tool_call_id: str
     result: Any
 
+
+@dataclass
+class DataChunk:
+    type: str = "data"
+    data: Any
+
+
 # Define the union type for AssistantStreamChunk
 AssistantStreamChunk = Union[
-    TextDeltaChunk,
-    ToolCallBeginChunk,
-    ToolCallDeltaChunk,
-    ToolResultChunk,
+    TextDeltaChunk, ToolCallBeginChunk, ToolCallDeltaChunk, ToolResultChunk, DataChunk
 ]

--- a/python/assistant-stream/src/assistant_stream/modules/tool_call.py
+++ b/python/assistant-stream/src/assistant_stream/modules/tool_call.py
@@ -25,7 +25,6 @@ class ToolCallController:
         self.loop = asyncio.get_event_loop()
 
         begin_chunk = ToolCallBeginChunk(
-            type="tool-call-begin",
             tool_call_id=self.tool_call_id,
             tool_name=self.tool_name,
         )
@@ -34,7 +33,6 @@ class ToolCallController:
     def append_args_text(self, args_text_delta: str) -> None:
         """Append an args text delta to the stream."""
         chunk = ToolCallDeltaChunk(
-            type="tool-call-delta",
             tool_call_id=self.tool_call_id,
             args_text_delta=args_text_delta,
         )
@@ -44,7 +42,6 @@ class ToolCallController:
         """Set the result of the tool call."""
 
         chunk = ToolResultChunk(
-            type="tool-result",
             tool_call_id=self.tool_call_id,
             result=result,
         )

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -20,6 +20,8 @@ class DataStreamEncoder(StreamEncoder):
             return f'c:{json.dumps({ "toolCallId": chunk.tool_call_id, "argsTextDelta": chunk.args_text_delta })}\n'
         elif chunk.type == "tool-result":
             return f'a:{json.dumps({ "toolCallId": chunk.tool_call_id, "result": chunk.result })}\n'
+        elif chunk.type == "data":
+            return f"2:{json.dumps([chunk.data])}\n"
         pass
 
     def get_media_type(self) -> str:


### PR DESCRIPTION
None

---
# EntelligenceAI PR Summary 
 The update introduces a `DataChunk` class to the `assistant-stream` module, enhancing data handling capabilities. Key files like `create_run.py` and `tool_call.py` now support these data chunks with improved type definitions. Additionally, the `data_stream.py` file has been updated to encode these chunks. The project version is incremented to 0.0.7, reflecting updates to the `starlette` package. 

