### PR TITLE
fix: do not throw on AI SDK annotation packets

### DIFF
--- a/.changeset/fair-pumas-relax.md
+++ b/.changeset/fair-pumas-relax.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: do not throw on AI SDK annotation packets

--- a/packages/react/src/runtimes/edge/streams/AssistantStreamChunkType.ts
+++ b/packages/react/src/runtimes/edge/streams/AssistantStreamChunkType.ts
@@ -1,9 +1,10 @@
-import { LanguageModelV1StreamPart } from "@ai-sdk/provider";
+import { JSONValue, LanguageModelV1StreamPart } from "@ai-sdk/provider";
 
 export enum AssistantStreamChunkType {
   TextDelta = "0",
   Data = "2",
   Error = "3",
+  Annotation = "8",
   ToolCall = "9",
   ToolCallResult = "a",
   ToolCallBegin = "b",
@@ -14,7 +15,8 @@ export enum AssistantStreamChunkType {
 
 export type AssistantStreamChunk = {
   [AssistantStreamChunkType.TextDelta]: string;
-  [AssistantStreamChunkType.Data]: unknown;
+  [AssistantStreamChunkType.Data]: JSONValue[];
+  [AssistantStreamChunkType.Annotation]: JSONValue[];
   [AssistantStreamChunkType.ToolCall]: {
     toolCallId: string;
     toolName: string;
@@ -55,4 +57,3 @@ export type AssistantStreamChunk = {
     "type"
   >;
 };
- 

--- a/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
+++ b/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
@@ -133,6 +133,7 @@ export function assistantDecoderStream() {
 
         // TODO
         case AssistantStreamChunkType.Data:
+        case AssistantStreamChunkType.Annotation:
           break;
 
         default: {


### PR DESCRIPTION
None

---
# EntelligenceAI PR Summary 
 This update resolves a minor issue in handling AI SDK annotation packets, ensuring error-free processing by modifying `AssistantStreamChunkType.ts` and `assistantDecoderStream.ts`.  

