### PR TITLE
feat: AssistantRuntimeCore.RenderComponent

### DIFF
--- a/.changeset/early-buckets-report.md
+++ b/.changeset/early-buckets-report.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-playground": patch
+"@assistant-ui/react": patch
+---
+
+feat: AssistantRuntimeCore.RenderComponent

--- a/.changeset/spotty-wolves-tell.md
+++ b/.changeset/spotty-wolves-tell.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+refactor: drop AssistantRuntimeCore.Provider due to causing app rerenders on runtime switch

--- a/packages/react-playground/src/lib/playground-runtime.ts
+++ b/packages/react-playground/src/lib/playground-runtime.ts
@@ -134,7 +134,6 @@ class PlaygroundThreadListRuntimeCore
 
 class PlaygroundRuntimeCore extends BaseAssistantRuntimeCore {
   public readonly threadList;
-  public readonly Provider = undefined;
 
   constructor(
     adapter: ChatModelAdapter,

--- a/packages/react/src/context/providers/AssistantRuntimeProvider.tsx
+++ b/packages/react/src/context/providers/AssistantRuntimeProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC, PropsWithChildren } from "react";
-import { Fragment, memo, useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { AssistantContext } from "../react/AssistantContext";
 import { makeAssistantToolUIsStore } from "../stores/AssistantToolUIs";
 import { ThreadRuntimeProvider } from "./ThreadRuntimeProvider";
@@ -47,9 +47,7 @@ const useThreadListStore = (runtime: AssistantRuntime) => {
 };
 
 const getRenderComponent = (runtime: AssistantRuntime) => {
-  return (
-    (runtime as { _core?: AssistantRuntimeCore })._core?.Provider ?? Fragment
-  );
+  return (runtime as { _core?: AssistantRuntimeCore })._core?.RenderComponent;
 };
 
 export const AssistantRuntimeProviderImpl: FC<
@@ -70,14 +68,13 @@ export const AssistantRuntimeProviderImpl: FC<
 
   return (
     <AssistantContext.Provider value={context}>
-      <RenderComponent>
-        <ThreadRuntimeProvider
-          runtime={runtime.thread}
-          listItemRuntime={runtime.threadList.mainItem}
-        >
-          {children}
-        </ThreadRuntimeProvider>
-      </RenderComponent>
+      {RenderComponent && <RenderComponent />}
+      <ThreadRuntimeProvider
+        runtime={runtime.thread}
+        listItemRuntime={runtime.threadList.mainItem}
+      >
+        {children}
+      </ThreadRuntimeProvider>
     </AssistantContext.Provider>
   );
 };

--- a/packages/react/src/runtimes/core/AssistantRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/AssistantRuntimeCore.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, PropsWithChildren } from "react";
+import { ComponentType } from "react";
 import type { ModelConfigProvider } from "../../types/ModelConfigTypes";
 import type { Unsubscribe } from "../../types/Unsubscribe";
 import { ThreadListRuntimeCore } from "./ThreadListRuntimeCore";
@@ -9,11 +9,10 @@ export type AssistantRuntimeCore = {
   registerModelConfigProvider: (provider: ModelConfigProvider) => Unsubscribe;
 
   /**
-   * A Provider component that wraps the app via `AssistantRuntimeProvider`.
+   * EXPERIMENTAL: A component that is rendered inside the AssistantRuntimeProvider.
    *
    * Note: This field is expected to never change.
-   * Refer to the source implementation of `ExternalStoreRuntimeCore`
-   * for an example of updating the provider via a zustand store.
+   * To update the component, use a zustand store.
    */
-  readonly Provider: ComponentType<PropsWithChildren> | undefined;
+  readonly RenderComponent?: ComponentType | undefined;
 };

--- a/packages/react/src/runtimes/core/BaseAssistantRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/BaseAssistantRuntimeCore.tsx
@@ -3,14 +3,10 @@ import type { Unsubscribe } from "../../types/Unsubscribe";
 import type { AssistantRuntimeCore } from "./AssistantRuntimeCore";
 import { ProxyConfigProvider } from "../../utils/ProxyConfigProvider";
 import { ThreadListRuntimeCore } from "./ThreadListRuntimeCore";
-import { ComponentType } from "react";
 
 export abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
   protected readonly _proxyConfigProvider = new ProxyConfigProvider();
   public abstract get threadList(): ThreadListRuntimeCore;
-  public abstract get Provider():
-    | ComponentType<React.PropsWithChildren>
-    | undefined;
 
   constructor() {}
 

--- a/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
@@ -90,10 +90,11 @@ export type ThreadRuntimeCore = Readonly<{
   messages: readonly ThreadMessage[];
   suggestions: readonly ThreadSuggestion[];
 
-  /**
-   * @deprecated This field is deprecated and will be removed in 0.8.0.
-   * Please migrate to using `AssistantRuntimeCore.Provider` instead.
-   */
+  // TODO deprecate for a more elegant solution
+  // /**
+  //  * @deprecated This field is deprecated and will be removed in 0.8.0.
+  //  * Please migrate to using `AssistantRuntimeCore.Provider` instead.
+  //  */
   extras: unknown;
 
   subscribe: (callback: () => void) => Unsubscribe;

--- a/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
@@ -1,4 +1,3 @@
-import { PropsWithChildren } from "react";
 import { AppendMessage, ThreadMessage } from "../../types";
 import { AttachmentAdapter } from "../attachment";
 import {
@@ -54,11 +53,6 @@ type ExternalStoreAdapterBase<T> = {
   isRunning?: boolean | undefined;
   messages: T[];
   suggestions?: readonly ThreadSuggestion[] | undefined;
-
-  /**
-   * @deprecated This field is deprecated and will be removed in 0.8.0. 
-   * Please migrate to `Provider` and a custom react context provider component instead.
-   */
   extras?: unknown;
 
   setMessages?: ((messages: T[]) => void) | undefined;
@@ -88,8 +82,6 @@ type ExternalStoreAdapterBase<T> = {
         copy?: boolean | undefined;
       }
     | undefined;
-
-  unstable_Provider?: React.ComponentType<PropsWithChildren> | undefined;
 };
 
 export type ExternalStoreAdapter<T = ThreadMessage> =

--- a/packages/react/src/runtimes/external-store/ExternalStoreRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreRuntimeCore.tsx
@@ -2,9 +2,6 @@ import { BaseAssistantRuntimeCore } from "../../internal";
 import { ExternalStoreThreadListRuntimeCore } from "./ExternalStoreThreadListRuntimeCore";
 import { ExternalStoreAdapter } from "./ExternalStoreAdapter";
 import { ExternalStoreThreadRuntimeCore } from "./ExternalStoreThreadRuntimeCore";
-import { Fragment } from "react/jsx-runtime";
-import { PropsWithChildren } from "react";
-import { create } from "zustand";
 
 const getThreadListAdapter = (store: ExternalStoreAdapter<any>) => {
   return {
@@ -15,13 +12,8 @@ const getThreadListAdapter = (store: ExternalStoreAdapter<any>) => {
 export class ExternalStoreRuntimeCore extends BaseAssistantRuntimeCore {
   public readonly threadList;
 
-  private useRenderComponent;
-
   constructor(adapter: ExternalStoreAdapter<any>) {
     super();
-    this.useRenderComponent = create(() => ({
-      RenderComponent: adapter.unstable_Provider ?? Fragment,
-    }));
     this.threadList = new ExternalStoreThreadListRuntimeCore(
       getThreadListAdapter(adapter),
       () =>
@@ -33,17 +25,5 @@ export class ExternalStoreRuntimeCore extends BaseAssistantRuntimeCore {
     // Update the thread list adapter and propagate store changes to the main thread
     this.threadList.__internal_setAdapter(getThreadListAdapter(adapter));
     this.threadList.getMainThreadRuntimeCore().__internal_setAdapter(adapter);
-
-    const RenderComponent = adapter.unstable_Provider ?? Fragment;
-    if (
-      RenderComponent !== this.useRenderComponent.getState().RenderComponent
-    ) {
-      this.useRenderComponent.setState({ RenderComponent }, true);
-    }
   }
-
-  public readonly Provider = ({ children }: PropsWithChildren) => {
-    const RenderComponent = this.useRenderComponent.getState().RenderComponent;
-    return <RenderComponent>{children}</RenderComponent>;
-  };
 }

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -5,7 +5,7 @@ import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInsta
 import { BaseSubscribable } from "./BaseSubscribable";
 import { EMPTY_THREAD_CORE } from "./EMPTY_THREAD_CORE";
 import { OptimisticState } from "./OptimisticState";
-import { FC, Fragment, PropsWithChildren, useEffect, useId } from "react";
+import { FC, Fragment, useEffect, useId } from "react";
 import { create } from "zustand";
 import { CloudInitializeResponse } from "./cloud/CloudContext";
 
@@ -152,8 +152,8 @@ export class RemoteThreadListThreadListRuntimeCore
     this._hookManager = new RemoteThreadListHookInstanceManager(
       adapter.runtimeHook,
     );
-    this.useRenderComponent = create(() => ({
-      RenderComponent: adapter.unstable_Provider ?? Fragment,
+    this.useProvider = create(() => ({
+      Provider: adapter.unstable_Provider ?? Fragment,
     }));
     this.__internal_setAdapter(adapter);
 
@@ -220,7 +220,7 @@ export class RemoteThreadListThreadListRuntimeCore
     this.switchToNewThread();
   }
 
-  private useRenderComponent;
+  private useProvider;
 
   public __internal_setAdapter(adapter: RemoteThreadListAdapter) {
     if (this._adapter === adapter) return;
@@ -229,11 +229,9 @@ export class RemoteThreadListThreadListRuntimeCore
     this._disposeOldAdapter?.();
     this._disposeOldAdapter = this._adapter.onInitialize(this._onInitialize);
 
-    const RenderComponent = adapter.unstable_Provider ?? Fragment;
-    if (
-      RenderComponent !== this.useRenderComponent.getState().RenderComponent
-    ) {
-      this.useRenderComponent.setState({ RenderComponent }, true);
+    const Provider = adapter.unstable_Provider ?? Fragment;
+    if (Provider !== this.useProvider.getState().Provider) {
+      this.useProvider.setState({ Provider }, true);
     }
 
     this._hookManager.setRuntimeHook(adapter.runtimeHook);
@@ -454,7 +452,7 @@ export class RemoteThreadListThreadListRuntimeCore
 
   private useBoundIds = create<string[]>(() => []);
 
-  public __internal_Provider: FC<PropsWithChildren> = ({ children }) => {
+  public __internal_RenderComponent: FC = () => {
     const id = useId();
     useEffect(() => {
       this.useBoundIds.setState((s) => [...s, id], true);
@@ -464,17 +462,15 @@ export class RemoteThreadListThreadListRuntimeCore
     }, []);
 
     const boundIds = this.useBoundIds();
-    const { RenderComponent } = this.useRenderComponent();
+    const { Provider } = this.useProvider();
 
     return (
-      <RenderComponent>
+      <Provider>
         {(boundIds.length === 0 || boundIds[0] === id) && (
           // only render if the component is the first one mounted
           <this._hookManager.__internal_RenderThreadRuntimes />
         )}
-
-        {children}
-      </RenderComponent>
+      </Provider>
     );
   };
 }

--- a/packages/react/src/runtimes/remote-thread-list/useRemoteThreadListRuntime.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/useRemoteThreadListRuntime.tsx
@@ -3,8 +3,12 @@ import { BaseAssistantRuntimeCore } from "../core/BaseAssistantRuntimeCore";
 import { RemoteThreadListThreadListRuntimeCore } from "./RemoteThreadListThreadListRuntimeCore";
 import { RemoteThreadListAdapter } from "./types";
 import { AssistantRuntimeImpl } from "../../internal";
+import { AssistantRuntimeCore } from "../core/AssistantRuntimeCore";
 
-class RemoteThreadListRuntimeCore extends BaseAssistantRuntimeCore {
+class RemoteThreadListRuntimeCore
+  extends BaseAssistantRuntimeCore
+  implements AssistantRuntimeCore
+{
   public readonly threadList;
 
   constructor(adapter: RemoteThreadListAdapter) {
@@ -12,8 +16,8 @@ class RemoteThreadListRuntimeCore extends BaseAssistantRuntimeCore {
     this.threadList = new RemoteThreadListThreadListRuntimeCore(adapter);
   }
 
-  public get Provider() {
-    return this.threadList.__internal_Provider;
+  public get RenderComponent() {
+    return this.threadList.__internal_RenderComponent;
   }
 }
 


### PR DESCRIPTION
replaces Provider, which had a regression because it would rerender the entire app on runtime change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
	- Removed deprecated `Provider` and `extras` properties across multiple runtime components
	- Updated component rendering logic to use `RenderComponent` instead of `Provider`
	- Simplified type definitions and removed unused imports

- **Chores**
	- Prepared codebase for upcoming version 0.8.0 by cleaning up experimental and deprecated APIs

The changes primarily focus on internal restructuring of runtime components with minimal user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->