### PR TITLE
fix: mark arrays in message types as readonly

### DIFF
--- a/.changeset/sour-rats-hear.md
+++ b/.changeset/sour-rats-hear.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: mark arrays in message types as readonly

--- a/packages/react/src/runtimes/edge/EdgeRuntimeRequestOptions.ts
+++ b/packages/react/src/runtimes/edge/EdgeRuntimeRequestOptions.ts
@@ -52,7 +52,8 @@ const CoreUserMessageSchema = z.object({
         Unstable_AudioContentPart,
       ]),
     )
-    .min(1),
+    .min(1)
+    .readonly(),
 });
 
 const CoreAssistantMessageSchema = z.object({
@@ -64,12 +65,13 @@ const CoreAssistantMessageSchema = z.object({
         CoreToolCallContentPartSchema,
       ]),
     )
-    .min(1),
+    .min(1)
+    .readonly(),
 });
 
 const CoreSystemMessageSchema = z.object({
   role: z.literal("system"),
-  content: z.tuple([TextContentPartSchema]),
+  content: z.tuple([TextContentPartSchema]).readonly(),
 });
 
 const CoreMessageSchema = z.discriminatedUnion("role", [
@@ -81,13 +83,13 @@ const CoreMessageSchema = z.discriminatedUnion("role", [
 export const EdgeRuntimeRequestOptionsSchema = z
   .object({
     system: z.string().optional(),
-    messages: z.array(CoreMessageSchema).min(1),
+    messages: z.array(CoreMessageSchema).min(1).readonly(),
     runConfig: z
       .object({
         custom: z.record(z.unknown()).optional(),
       })
       .optional(),
-    tools: z.array(LanguageModelV1FunctionToolSchema).optional(),
+    tools: z.array(LanguageModelV1FunctionToolSchema).readonly().optional(),
     unstable_assistantMessageId: z.string().optional(),
   })
   .merge(LanguageModelV1CallSettingsSchema)

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -22,7 +22,7 @@ export type ThreadMessageLike = {
   role: "assistant" | "user" | "system";
   content:
     | string
-    | (
+    | readonly (
         | TextContentPart
         | ImageContentPart
         | Unstable_AudioContentPart
@@ -33,9 +33,9 @@ export type ThreadMessageLike = {
   id?: string | undefined;
   createdAt?: Date | undefined;
   status?: MessageStatus | undefined;
-  attachments?: CompleteAttachment[] | undefined;
+  attachments?: readonly CompleteAttachment[] | undefined;
   metadata?: {
-    steps?: ThreadStep[] | undefined;
+    steps?: readonly ThreadStep[] | undefined;
     custom?: Record<string, unknown> | undefined;
   };
 };

--- a/packages/react/src/runtimes/external-store/external-message-converter.tsx
+++ b/packages/react/src/runtimes/external-store/external-message-converter.tsx
@@ -32,7 +32,7 @@ type ChunkResult<T> = {
 };
 
 const joinExternalMessages = (
-  messages: useExternalMessageConverter.Message[],
+  messages: readonly useExternalMessageConverter.Message[],
 ): ThreadMessageLike => {
   const assistantMessage: ThreadMessageLike & { content: any[] } = {
     role: "assistant",

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -121,7 +121,7 @@ export type MessageStatus =
 
 export type ThreadSystemMessage = MessageCommonProps & {
   readonly role: "system";
-  readonly content: [TextContentPart];
+  readonly content: readonly [TextContentPart];
   readonly metadata: {
     readonly custom: Record<string, unknown>;
   };
@@ -129,7 +129,7 @@ export type ThreadSystemMessage = MessageCommonProps & {
 
 export type ThreadUserMessage = MessageCommonProps & {
   readonly role: "user";
-  readonly content: ThreadUserContentPart[];
+  readonly content: readonly ThreadUserContentPart[];
   readonly attachments: readonly CompleteAttachment[];
   readonly metadata: {
     readonly custom: Record<string, unknown>;
@@ -138,10 +138,10 @@ export type ThreadUserMessage = MessageCommonProps & {
 
 export type ThreadAssistantMessage = MessageCommonProps & {
   readonly role: "assistant";
-  readonly content: ThreadAssistantContentPart[];
+  readonly content: readonly ThreadAssistantContentPart[];
   readonly status: MessageStatus;
   readonly metadata: {
-    readonly steps: ThreadStep[];
+    readonly steps: readonly ThreadStep[];
     readonly custom: Record<string, unknown>;
   };
 };
@@ -162,7 +162,7 @@ export type AppendMessage = CoreMessage & {
 type BaseThreadMessage = {
   readonly status?: ThreadAssistantMessage["status"];
   readonly metadata: {
-    readonly steps?: ThreadStep[];
+    readonly steps?: readonly ThreadStep[];
     readonly custom: Record<string, unknown>;
   };
   readonly attachments?: ThreadUserMessage["attachments"];
@@ -183,17 +183,17 @@ export type CoreAssistantContentPart =
 
 export type CoreSystemMessage = {
   role: "system";
-  content: [TextContentPart];
+  content: readonly [TextContentPart];
 };
 
 export type CoreUserMessage = {
   role: "user";
-  content: CoreUserContentPart[];
+  content: readonly CoreUserContentPart[];
 };
 
 export type CoreAssistantMessage = {
   role: "assistant";
-  content: CoreAssistantContentPart[];
+  content: readonly CoreAssistantContentPart[];
 };
 
 export type CoreMessage =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
    - Enhanced type safety by adding readonly modifiers to various array and tuple schemas
    - Improved immutability of message content, attachments, and metadata across multiple type definitions
    - Enforced stricter data structure constraints to prevent unintended modifications

- **Bug Fixes**
    - Prevented potential side effects by making core message and thread message arrays immutable

The changes focus on improving type safety and data integrity in the application's message handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->