### PR TITLE
feat: message.metadata.unstable_data

### DIFF
--- a/.changeset/wet-wombats-relate.md
+++ b/.changeset/wet-wombats-relate.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: message.metadata.unstable_data

--- a/packages/react-playground/src/lib/converters.ts
+++ b/packages/react-playground/src/lib/converters.ts
@@ -87,7 +87,7 @@ const threadMessagesFromOpenAI = (
 
 const threadMessagesToOpenAI = (
   system: string | undefined,
-  messages: CoreMessage[],
+  messages: readonly CoreMessage[],
 ) => {
   const systemMessage: CoreMessage | undefined = system
     ? { role: "system", content: [{ type: "text", text: system }] }

--- a/packages/react-playground/src/lib/playground-runtime.ts
+++ b/packages/react-playground/src/lib/playground-runtime.ts
@@ -276,7 +276,11 @@ export class PlaygroundThreadRuntimeCore implements INTERNAL.ThreadRuntimeCore {
       role: "assistant",
       status: { type: "running" },
       content: [],
-      metadata: { steps: [], custom: {} },
+      metadata: {
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
       createdAt: new Date(),
     };
 
@@ -292,6 +296,7 @@ export class PlaygroundThreadRuntimeCore implements INTERNAL.ThreadRuntimeCore {
         content: m.content ?? message.content,
         status: m.status ?? message.status,
         metadata: {
+          unstable_data: [],
           steps: m.metadata?.steps ?? message.metadata?.steps,
           custom: m.metadata?.custom ?? message.metadata?.custom,
         },

--- a/packages/react-playground/src/lib/playground-runtime.ts
+++ b/packages/react-playground/src/lib/playground-runtime.ts
@@ -296,7 +296,8 @@ export class PlaygroundThreadRuntimeCore implements INTERNAL.ThreadRuntimeCore {
         content: m.content ?? message.content,
         status: m.status ?? message.status,
         metadata: {
-          unstable_data: [],
+          unstable_data:
+            m.metadata?.unstable_data ?? message.metadata?.unstable_data,
           steps: m.metadata?.steps ?? message.metadata?.steps,
           custom: m.metadata?.custom ?? message.metadata?.custom,
         },

--- a/packages/react/src/runtimes/edge/converters/fromCoreMessage.ts
+++ b/packages/react/src/runtimes/edge/converters/fromCoreMessage.ts
@@ -43,7 +43,7 @@ export const fromCoreMessage = (
         }),
         status,
 
-        metadata: { steps: [], custom: {} },
+        metadata: { unstable_data: [], steps: [], custom: {} },
       } satisfies ThreadMessage;
 
     case "user":

--- a/packages/react/src/runtimes/edge/converters/fromLanguageModelMessages.ts
+++ b/packages/react/src/runtimes/edge/converters/fromLanguageModelMessages.ts
@@ -78,7 +78,10 @@ export const fromLanguageModelMessages = (
         if (mergeSteps) {
           const previousMessage = messages[messages.length - 1];
           if (previousMessage?.role === "assistant") {
-            previousMessage.content.push(...newContent);
+            previousMessage.content = [
+              ...previousMessage.content,
+              ...newContent,
+            ];
             break;
           }
         }

--- a/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
+++ b/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
@@ -131,8 +131,14 @@ export function assistantDecoderStream() {
           break;
         }
 
-        // TODO
         case AssistantStreamChunkType.Data:
+          controller.enqueue({
+            type: "data",
+            data: value,
+          });
+          break;
+
+        // TODO
         case AssistantStreamChunkType.Annotation:
           break;
 

--- a/packages/react/src/runtimes/edge/streams/assistantEncoderStream.ts
+++ b/packages/react/src/runtimes/edge/streams/assistantEncoderStream.ts
@@ -44,6 +44,14 @@ export function assistantEncoderStream() {
           break;
         }
 
+        case "data": {
+          controller.enqueue({
+            type: AssistantStreamChunkType.Data,
+            value: chunk.data,
+          });
+          break;
+        }
+
         // ignore
         case "tool-call":
         case "response-metadata":

--- a/packages/react/src/runtimes/edge/streams/runResultStream.ts
+++ b/packages/react/src/runtimes/edge/streams/runResultStream.ts
@@ -1,16 +1,16 @@
-import { ChatModelRunResult } from "../../local/ChatModelAdapter";
+import { CoreChatModelRunResult } from "../../local/ChatModelAdapter";
 import { parsePartialJson } from "../partial-json/parse-partial-json";
 import { LanguageModelV1StreamPart } from "@ai-sdk/provider";
 import { ToolResultStreamPart } from "./toolResultStream";
 import { MessageStatus, ToolCallContentPart } from "../../../types";
 
 export function runResultStream() {
-  let message: ChatModelRunResult = {
+  let message: CoreChatModelRunResult = {
     content: [],
     status: { type: "running" },
   };
 
-  return new TransformStream<ToolResultStreamPart, ChatModelRunResult>({
+  return new TransformStream<ToolResultStreamPart, CoreChatModelRunResult>({
     transform(chunk, controller) {
       const chunkType = chunk.type;
       switch (chunkType) {
@@ -99,7 +99,10 @@ export function runResultStream() {
   });
 }
 
-const appendOrUpdateText = (message: ChatModelRunResult, textDelta: string) => {
+const appendOrUpdateText = (
+  message: CoreChatModelRunResult,
+  textDelta: string,
+) => {
   let contentParts = message.content ?? [];
   let contentPart = message.content?.at(-1);
   if (contentPart?.type !== "text") {
@@ -115,11 +118,11 @@ const appendOrUpdateText = (message: ChatModelRunResult, textDelta: string) => {
 };
 
 const appendOrUpdateToolCall = (
-  message: ChatModelRunResult,
+  message: CoreChatModelRunResult,
   toolCallId: string,
   toolName: string,
   argsTextDelta: string,
-): ChatModelRunResult => {
+): CoreChatModelRunResult => {
   let contentParts = message.content ?? [];
   const contentPartIdx = contentParts.findIndex(
     (c) => c.type === "tool-call" && c.toolCallId === toolCallId,
@@ -159,7 +162,7 @@ const appendOrUpdateToolCall = (
 };
 
 const appendOrUpdateToolResult = (
-  message: ChatModelRunResult,
+  message: CoreChatModelRunResult,
   toolCallId: string,
   toolName: string,
   result: any,
@@ -192,9 +195,9 @@ const appendOrUpdateToolResult = (
 };
 
 const appendData = (
-  message: ChatModelRunResult,
+  message: CoreChatModelRunResult,
   chunk: ToolResultStreamPart & { type: "data" },
-): ChatModelRunResult => {
+): CoreChatModelRunResult => {
   return {
     ...message,
     metadata: {
@@ -205,9 +208,9 @@ const appendData = (
 };
 
 const appendStepFinish = (
-  message: ChatModelRunResult,
+  message: CoreChatModelRunResult,
   chunk: ToolResultStreamPart & { type: "step-finish" },
-): ChatModelRunResult => {
+): CoreChatModelRunResult => {
   const { type, ...rest } = chunk;
   const steps = [
     ...(message.metadata?.steps ?? []),
@@ -225,9 +228,9 @@ const appendStepFinish = (
 };
 
 const appendOrUpdateFinish = (
-  message: ChatModelRunResult,
+  message: CoreChatModelRunResult,
   chunk: LanguageModelV1StreamPart & { type: "finish" },
-): ChatModelRunResult => {
+): CoreChatModelRunResult => {
   const { type, ...rest } = chunk;
 
   const steps = [
@@ -274,8 +277,8 @@ const getStatus = (
 };
 
 const appendOrUpdateCancel = (
-  message: ChatModelRunResult,
-): ChatModelRunResult => {
+  message: CoreChatModelRunResult,
+): CoreChatModelRunResult => {
   return {
     ...message,
     status: {

--- a/packages/react/src/runtimes/edge/streams/toolResultStream.ts
+++ b/packages/react/src/runtimes/edge/streams/toolResultStream.ts
@@ -1,10 +1,14 @@
 import { Tool } from "../../../types/ModelConfigTypes";
-import { LanguageModelV1StreamPart } from "@ai-sdk/provider";
+import { JSONValue, LanguageModelV1StreamPart } from "@ai-sdk/provider";
 import { z } from "zod";
 import sjson from "secure-json-parse";
 
 export type ToolResultStreamPart =
   | LanguageModelV1StreamPart
+  | {
+      type: "data";
+      data: JSONValue[];
+    }
   | {
       type: "tool-result";
       toolCallType: "function";
@@ -107,6 +111,7 @@ export function toolResultStream(
         case "finish":
         case "error":
         case "response-metadata":
+        case "data":
           break;
 
         default: {

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -35,6 +35,7 @@ export type ThreadMessageLike = {
   status?: MessageStatus | undefined;
   attachments?: readonly CompleteAttachment[] | undefined;
   metadata?: {
+    unstable_data?: readonly Record<string, unknown>[] | undefined;
     steps?: readonly ThreadStep[] | undefined;
     custom?: Record<string, unknown> | undefined;
   };
@@ -98,6 +99,7 @@ export const fromThreadMessageLike = (
           .filter((c) => !!c),
         status: status ?? fallbackStatus,
         metadata: {
+          unstable_data: metadata?.unstable_data ?? [],
           custom: metadata?.custom ?? {},
           steps: metadata?.steps ?? [],
         },

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { JSONValue } from "@ai-sdk/provider";
 import type {
   MessageStatus,
   RunConfig,
@@ -19,7 +18,7 @@ export type ChatModelRunResult = {
   content?: ThreadAssistantContentPart[] | undefined;
   status?: MessageStatus | undefined;
   metadata?: {
-    unstable_data?: JSONValue[] | undefined;
+    unstable_data?: unknown[] | undefined;
     steps?: ThreadStep[] | undefined;
     custom?: Record<string, unknown> | undefined;
   };

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { JSONValue } from "@ai-sdk/provider";
 import type {
   MessageStatus,
   RunConfig,
@@ -18,6 +19,7 @@ export type ChatModelRunResult = {
   content?: ThreadAssistantContentPart[] | undefined;
   status?: MessageStatus | undefined;
   metadata?: {
+    unstable_data?: JSONValue[] | undefined;
     steps?: ThreadStep[] | undefined;
     custom?: Record<string, unknown> | undefined;
   };

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -3,9 +3,11 @@
 import type {
   MessageStatus,
   RunConfig,
+  TextContentPart,
   ThreadAssistantContentPart,
   ThreadMessage,
   ThreadStep,
+  ToolCallContentPart,
 } from "../../types/AssistantTypes";
 import type { ModelConfig } from "../../types/ModelConfigTypes";
 
@@ -22,6 +24,10 @@ export type ChatModelRunResult = {
     steps?: ThreadStep[] | undefined;
     custom?: Record<string, unknown> | undefined;
   };
+};
+
+export type CoreChatModelRunResult = Omit<ChatModelRunResult, "content"> & {
+  content: (TextContentPart | ToolCallContentPart)[];
 };
 
 export type ChatModelRunOptions = {

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -120,7 +120,7 @@ export class LocalThreadRuntimeCore
       role: "assistant",
       status: { type: "running" },
       content: [],
-      metadata: { steps: [], custom: {} },
+      metadata: { unstable_data: [], steps: [], custom: {} },
       createdAt: new Date(),
     };
 

--- a/packages/react/src/runtimes/remote-thread-list/cloud/useCloudThreadListRuntime.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/cloud/useCloudThreadListRuntime.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { AssistantRuntime } from "@assistant-ui/react";
 import { PropsWithChildren, useEffect, useMemo, useRef } from "react";
 import { useRemoteThreadListRuntime } from "../useRemoteThreadListRuntime";
 import { AssistantCloud } from "./AssistantCloud";
 import { CloudContext, CloudInitializeResponse } from "./CloudContext";
+import { AssistantRuntime } from "../../../api";
 
 type ThreadData = {
   externalId: string;

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { CompleteAttachment } from "./AttachmentTypes";
+import { JSONValue } from "@ai-sdk/provider";
 
 export type MessageRole = "user" | "assistant" | "system";
 
@@ -141,7 +142,7 @@ export type ThreadAssistantMessage = MessageCommonProps & {
   readonly content: readonly ThreadAssistantContentPart[];
   readonly status: MessageStatus;
   readonly metadata: {
-    readonly unstable_data: readonly Record<string, unknown>[];
+    readonly unstable_data: readonly unknown[];
     readonly steps: readonly ThreadStep[];
     readonly custom: Record<string, unknown>;
   };
@@ -163,7 +164,7 @@ export type AppendMessage = CoreMessage & {
 type BaseThreadMessage = {
   readonly status?: ThreadAssistantMessage["status"];
   readonly metadata: {
-    readonly unstable_data?: readonly Record<string, unknown>[];
+    readonly unstable_data?: readonly unknown[];
     readonly steps?: readonly ThreadStep[];
     readonly custom: Record<string, unknown>;
   };

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { CompleteAttachment } from "./AttachmentTypes";
-import { JSONValue } from "@ai-sdk/provider";
 
 export type MessageRole = "user" | "assistant" | "system";
 

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -141,6 +141,7 @@ export type ThreadAssistantMessage = MessageCommonProps & {
   readonly content: readonly ThreadAssistantContentPart[];
   readonly status: MessageStatus;
   readonly metadata: {
+    readonly unstable_data: readonly Record<string, unknown>[];
     readonly steps: readonly ThreadStep[];
     readonly custom: Record<string, unknown>;
   };
@@ -162,6 +163,7 @@ export type AppendMessage = CoreMessage & {
 type BaseThreadMessage = {
   readonly status?: ThreadAssistantMessage["status"];
   readonly metadata: {
+    readonly unstable_data?: readonly Record<string, unknown>[];
     readonly steps?: readonly ThreadStep[];
     readonly custom: Record<string, unknown>;
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for `unstable_data` in message metadata across multiple components
	- Enhanced stream processing to handle new data chunk types
	- Improved flexibility in message type definitions

- **Refactor**
	- Updated type definitions to include more flexible metadata structures
	- Refined stream handling for different message types

- **Chores**
	- Updated import statements and type imports
	- Adjusted internal type handling for better type safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->