### PR TITLE
fix(langgraph): missing type for abortSignal

### DIFF
--- a/packages/react-langgraph/CHANGELOG.md
+++ b/packages/react-langgraph/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react-langgraph
 
+## 0.1.13
+
+### Patch Changes
+
+- fix: missing type for abortSignal
+
 ## 0.1.12
 
 ### Patch Changes

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-langgraph",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -12,18 +12,20 @@ export type LangGraphSendMessageConfig = {
   runConfig?: unknown;
 };
 
+export type LangGraphStreamCallback<TMessage> = (
+  messages: TMessage[],
+  config: LangGraphSendMessageConfig & { abortSignal: AbortSignal },
+) => Promise<
+  AsyncGenerator<{
+    event: string;
+    data: any;
+  }>
+>;
+
 export const useLangGraphMessages = <TMessage>({
   stream,
 }: {
-  stream: (
-    messages: TMessage[],
-    config: LangGraphSendMessageConfig & { abortSignal: AbortSignal },
-  ) => Promise<
-    AsyncGenerator<{
-      event: string;
-      data: any;
-    }>
-  >;
+  stream: LangGraphStreamCallback<TMessage>;
 }) => {
   const [messages, setMessages] = useState<TMessage[]>([]);
   const abortControllerRef = useRef<AbortController | null>(null);

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -10,6 +10,7 @@ import { convertLangchainMessages } from "./convertLangchainMessages";
 import {
   LangGraphCommand,
   LangGraphSendMessageConfig,
+  LangGraphStreamCallback,
   useLangGraphMessages,
 } from "./useLangGraphMessages";
 import { SimpleImageAttachmentAdapter } from "@assistant-ui/react";
@@ -116,15 +117,7 @@ export const useLangGraphRuntime = ({
    */
   unstable_allowImageAttachments?: boolean | undefined;
   unstable_allowCancellation?: boolean | undefined;
-  stream: (
-    messages: LangChainMessage[],
-    config: LangGraphSendMessageConfig,
-  ) => Promise<
-    AsyncGenerator<{
-      event: string;
-      data: any;
-    }>
-  >;
+  stream: LangGraphStreamCallback<LangChainMessage>;
   /**
    * @deprecated For thread management use `useCloudThreadListRuntime` instead. This option will be removed in a future version.
    */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for @assistant-ui/react-langgraph v0.1.13

- **Bug Fixes**
  - Added missing type definition for `abortSignal` in stream callback

- **Chores**
  - Updated package version to 0.1.13
  - Minor type system improvements for stream callback functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->